### PR TITLE
Changed artifact versioning to use default SBT plugin versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Setup [SBT](http://github.com/harrah/xsbt/).
 Add plugin to project in `project/plugins.sbt`:
 
 ```scala
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")
 ```
 
 Inject plugin settings into project in `build.sbt`:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -71,9 +71,6 @@ object PluginBuild extends Build {
 	}
 
 	def sharedSettings = sonatypeSettings ++ Seq(
-		projectID <<= (organization,moduleName,version,artifacts,crossPaths){ (org,module,version,as,crossEnabled) =>
-			ModuleID(org, module, version).cross(crossEnabled).artifacts(as : _*)
-		},
 		organization := "com.github.siasia",
 		credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
 		pomUrl := "http://github.com/siasia/xsbt-web-plugin",
@@ -90,10 +87,6 @@ object PluginBuild extends Build {
 			"Artyom Olshevskiy",
 			"siasiamail@gmail.com"
 		))		
-	)
-
-	def appendedSettings = Seq(
-		version <<= (sbtVersion, version)(_ + "-" + _)
 	)
 
 	def rootSettings: Seq[Setting[_]] = sharedSettings ++ scriptedSettings ++ Seq(
@@ -115,7 +108,7 @@ object PluginBuild extends Build {
 		publishLocal <<= (publishLocal in commons, publishLocal) map ((_, p) => p),
 		scalacOptions += "-deprecation",
 		scriptedBufferLog := false
-	) ++ appendedSettings
+	)
 
 	def commonsSettings = sharedSettings ++ Seq(
 		name := "plugin-commons",
@@ -124,7 +117,7 @@ object PluginBuild extends Build {
 			(v) => Seq(
 				"org.scala-sbt" % "classpath" % v % "provided"
 			)}
-	) ++ appendedSettings
+	)
 	
 	lazy val root = Project("root", file(".")) settings(rootSettings :_*) dependsOn(commons)
 	lazy val commons = Project("commons", file("commons")) settings(commonsSettings :_*)

--- a/set-sbt-test-plugin-version.sh
+++ b/set-sbt-test-plugin-version.sh
@@ -7,6 +7,6 @@ fi
 PLUGIN_VERSION=$1
 for group in $(ls src/sbt-test); do
 		for test_dir in $(ls src/sbt-test/$group); do
-				echo "libraryDependencies <+= sbtVersion(v => \"com.github.siasia\" %% \"xsbt-web-plugin\" % (v+\"-$PLUGIN_VERSION\"))" > src/sbt-test/$group/$test_dir/project/plugins.sbt
+				echo "addSbtPlugin(\"com.github.siasia\" % \"xsbt-web-plugin\" % \"$PLUGIN_VERSION\")" > src/sbt-test/$group/$test_dir/project/plugins.sbt
 		done
 done

--- a/src/sbt-test/web/jetty-dep-conf/project/plugins.sbt
+++ b/src/sbt-test/web/jetty-dep-conf/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/jetty-env/project/plugins.sbt
+++ b/src/sbt-test/web/jetty-env/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/jsp/project/plugins.sbt
+++ b/src/sbt-test/web/jsp/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/multi-jetty/project/plugins.sbt
+++ b/src/sbt-test/web/multi-jetty/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/sbt-provided/project/plugins.sbt
+++ b/src/sbt-test/web/sbt-provided/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/servlet-direct/project/plugins.sbt
+++ b/src/sbt-test/web/servlet-direct/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/servlet-nodup/project/plugins.sbt
+++ b/src/sbt-test/web/servlet-nodup/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")

--- a/src/sbt-test/web/servlet/project/plugins.sbt
+++ b/src/sbt-test/web/servlet/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+addSbtPlugin("com.github.siasia" % "xsbt-web-plugin" % "0.2.11.1")


### PR DESCRIPTION
The previous artifact versioning did not support binary compatible versioning introduced in SBT 0.12.  As a result versions of this plugin built for for SBT 0.12.0 would not be automatically used by projects
using SBT 0.12.1.

I assume that the custom versioning is left over from when SBT had issues publishing plugins in Maven repos.  I believe this has since been fixed.  Let me know if you have issues 
