### PR TITLE
Copy resources in classpath-defined order.

### DIFF
--- a/src/main/scala/com/github/siasia/WarPlugin.scala
+++ b/src/main/scala/com/github/siasia/WarPlugin.scala
@@ -26,20 +26,20 @@ object WarPlugin extends Plugin {
 
 			val (libs, directories) = classpath.toList.partition(ClasspathUtilities.isArchive)
 			val wcToCopy = for {
-				dir <- webappResources
+				dir <- webappResources.reverse
 				file <- dir.descendentsExcept("*", filter).get
 				val target = Path.rebase(dir, warPath)(file).get
 			} yield (file, target)
 			val classesAndResources = for {
-				dir <- directories
+				dir <- directories.reverse
 				file <- dir.descendentsExcept("*", filter).get
 				val target = Path.rebase(dir, classesTargetDirectory)(file).get
 			} yield (file, target)
 			if(log.atLevel(Level.Debug))
 				directories.foreach(d => log.debug(" Copying the contents of directory " + d + " to " + classesTargetDirectory))
 
-			val copiedWebapp = IO.copy(wcToCopy)
-			val copiedClasses = IO.copy(classesAndResources)
+			val copiedWebapp = IO.copy(wcToCopy, overwrite = true, preserveLastModified = true)
+			val copiedClasses = IO.copy(classesAndResources, overwrite = true, preserveLastModified = true)
 			val copiedLibs = copyFlat(libs, webLibDirectory)
 			val toRemove = scala.collection.mutable.HashSet((warPath ** "*").get.toSeq : _*)
 			toRemove --= copiedWebapp


### PR DESCRIPTION
The current behavior copies the resources in such a way that, in the
case of conflicting filenames, the one with the latest timestamp wins.
This behavior results from the use of IO.copy with the default value for
the "overwrite" parameter (false), which will only overwrite a file if
the timestamp is later.

Instead, conflicts should be resolved according to the provided
classpath in the same way that the JVM would resolve such conflicts,
i.e., the class found via the earliest classpath entry wins.

See "Specification order" in:
http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/classpath.html

To accomplish this, we copy resources over in _reverse_ classpath order,
telling IO.copy to always overwrite.
