### PR TITLE
Update PluginKeys.scala

### DIFF
--- a/src/main/scala/com/github/siasia/PluginKeys.scala
+++ b/src/main/scala/com/github/siasia/PluginKeys.scala
@@ -15,7 +15,7 @@ object PluginKeys extends Plugin {
 	lazy val DefaultConf = Compile
 	lazy val DefaultClasspathConf = Runtime
 	lazy val port = SettingKey[Int]("port")
-	lazy val ssl = SettingKey[Option[(Int,String,String,String)]]("ssl")
+	lazy val ssl = TaskKey[Option[(Int,String,String,String)]]("ssl")
 	lazy val apps = TaskKey[Seq[(String, Deployment)]]("apps")
 	lazy val start = TaskKey[Unit]("start")
 	lazy val discoveredContexts = TaskKey[Seq[String]]("discovered-contexts")


### PR DESCRIPTION
SSL should be a task key since in multi project the keystore is in different places. I use this in my multi project setup a lot.
