### PR TITLE
Fix for #113

### DIFF
--- a/src/main/scala/Container.scala
+++ b/src/main/scala/Container.scala
@@ -32,7 +32,7 @@ case class Container(name: String) {
     def newRunner(ref: ProjectRef, state: State) = {
       implicit val s = state
       val classpath = Build.data(fullClasspath in (ref, Configuration))
-      state.put(attribute, Runner(scalaInstance in ref, classpath))
+      state.put(attribute, Runner(classpath))
     }
   }
 

--- a/src/main/scala/Runner.scala
+++ b/src/main/scala/Runner.scala
@@ -14,9 +14,8 @@ object Runner {
     classOf[Tomcat7Runner].getName
   )
   def packages = Seq("org.mortbay", "org.eclipse.jetty", "org.apache.catalina")
-  def apply(instance: ScalaInstance, classpath: Seq[File]): Runner = {
-    val parentLoader = instance.loader
-    val loader: ClassLoader = toLoader(classpath, parentLoader)
+  def apply(classpath: Seq[File]): Runner = {
+    val loader: ClassLoader = toLoader(classpath)
 
     val runner = guessRunner(loader, runners)
     runner.setLoader(loader)


### PR DESCRIPTION
For some reason we were including Scala libs in the base classloader for
servlet containers.  This resulted in Scala libs being on the classpath
twice.  I changed to base classloader so now it only conatins the container
libs and the root classloader.
