### PR TITLE
Real fix for #113

### DIFF
--- a/src/sbt-test/runners/tomcat-7/changes/MyServlet1.scala
+++ b/src/sbt-test/runners/tomcat-7/changes/MyServlet1.scala
@@ -6,10 +6,10 @@ import javax.servlet.http.HttpServletResponse;
 
 class MyServlet extends HttpServlet {
 
-  val html = """<HTML>
+  val html = <HTML>
     <HEAD><TITLE>Hello, Scala!</TITLE></HEAD>
     <BODY>Hello, Scala! This is a servlet.</BODY>
-  </HTML>"""
+  </HTML>
 
   override def doGet(req:HttpServletRequest, resp:HttpServletResponse) {
     resp.setContentType("text/html")

--- a/src/sbt-test/runners/tomcat-7/changes/MyServlet2.scala
+++ b/src/sbt-test/runners/tomcat-7/changes/MyServlet2.scala
@@ -6,10 +6,10 @@ import javax.servlet.http.HttpServletResponse;
 
 class MyServlet extends HttpServlet {
 
-  val html = """<HTML>
+  val html = <HTML>
     <HEAD><TITLE>Hello, Scala 2!</TITLE></HEAD>
     <BODY>Hello, Scala 2! This is a servlet.</BODY>
-  </HTML>"""
+  </HTML>
 
   override def doGet(req:HttpServletRequest, resp:HttpServletResponse) {
     resp.setContentType("text/html")

--- a/src/sbt-test/runners/tomcat-7/changes/MyServlet3.scala
+++ b/src/sbt-test/runners/tomcat-7/changes/MyServlet3.scala
@@ -6,10 +6,10 @@ import javax.servlet.http.HttpServletResponse;
 
 class MyServlet extends HttpServlet {
 
-  val html = """<HTML>
+  val html = <HTML>
     <HEAD><TITLE>Hello, Scala 3!</TITLE></HEAD>
     <BODY>Hello, Scala 3! This is a servlet.</BODY>
-  </HTML>"""
+  </HTML>
 
   override def doGet(req:HttpServletRequest, resp:HttpServletResponse) {
     resp.setContentType("text/html")


### PR DESCRIPTION
Apparently the cause of this issue is that Tomcat checks the System
classloader before it checks any others.  Unfortunately, the sbt-
lauch.jar is on the system classloader.  It appears to contain a version
of the Scala standard lib that has been run through Proguard.  As a
result, it is missing a bunch of methods.  To fix this I modified the
Tomcat classloader so it uses the root classloader instead of the system
classloader.  This is kind of a hack because Tomcat doesn't provided a
way to do this.
