### PR TITLE
Removed Tomcat automatic reloading

### DIFF
--- a/src/tomcat-7/scala/Tomcat7Runner.scala
+++ b/src/tomcat-7/scala/Tomcat7Runner.scala
@@ -108,9 +108,7 @@ class Tomcat7Runner extends Runner {
       deployment.webappResources.tail.foreach { file =>
         context.addWatchedResource(file.getAbsolutePath)
       }
-      
-      context.setReloadable(true)
-      
+
       val webLoader = new ReloadableWebappLoader(loader)
       deployment.classpath.foreach(file => webLoader.addRepository(file.toURI.toURL.toString))
       context.setLoader(webLoader)


### PR DESCRIPTION
Tomcat was also watching for file changes and automatically reloading
the contexts.  This is kind of annoying if you are also using SBTs
triggered actions to reload the contexts.
