### PR TITLE
Handle non-jar classpath components. (Issue #125)

### DIFF
--- a/src/main/scala/WarPlugin.scala
+++ b/src/main/scala/WarPlugin.scala
@@ -24,7 +24,7 @@ object WarPlugin extends Plugin {
       val webLibDirectory = webInfPath / "lib"
       val classesTargetDirectory = webInfPath / "classes"
 
-      val (libs, directories) = classpath.toList.partition(ClasspathUtilities.isArchive)
+      val (libs, directories) = classpath.toList.filter(_.exists).partition(!_.isDirectory)
       val wcToCopy = for {
         dir <- webappResources.reverse
         file <- dir.descendantsExcept("*", filter).get


### PR DESCRIPTION
packageWarTask.packageWarTask handles directories and jar archives
separately: Archives are copied one by one, while directories are
copied recursively.

Without this patch, the separation between directories and archives is
made using ClasspathUtilities.isArchive. This has two disadvantages:

1) ClasspathUtilities.isArchive, without the optional parameter
contentFallback, only looks at the filename. So an archive which is
not named .jar or .zip is not correctly identified.

2) Even using contentFallback, ClasspathUtilities.isArchive would,
of course, return 'false' for non-archive files. This would make
packageWarTask think it's a directory.

Both cases lead to a rather confusing error message:

java.io.FileNotFoundException: /<path to project>/target/webapp/WEB-INF/classes (Is a directory)

With this patch, instead, packageWarTask uses _.isDirectory to separate
between directories and archives. This handles non-archive files like
archives, by just adding them to the classpath, without failing the build.

Additionally, filter out non-existing classpath components.

This fixes JamesEarlDouglas/xsbt-web-plugin#125
