### PR TITLE
Avoid file locking problem on windows set useFileMappedBuffer to false for jetty

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.4
-#sbt.version=0.13.0
+#sbt.version=0.12.4
+sbt.version=0.13.0

--- a/src/jetty-7/scala/Jetty7Runner.scala
+++ b/src/jetty-7/scala/Jetty7Runner.scala
@@ -44,6 +44,7 @@ class Jetty7Runner extends Runner {
     import deployment._
     val context = new WebAppContext()
     context.setContextPath(contextPath)
+    context.getInitParams().put("org.eclipse.jetty.servlet.Default.useFileMappedBuffer", "false")
     context.setBaseResource(
       new ResourceCollection(
         webappResources.map(_.getPath).toArray

--- a/src/jetty-9/scala/Jetty9Runner.scala
+++ b/src/jetty-9/scala/Jetty9Runner.scala
@@ -42,6 +42,7 @@ class Jetty9Runner extends Runner {
     import deployment._
     val context = new WebAppContext()
     context.setContextPath(contextPath)
+    context.getInitParams().put("org.eclipse.jetty.servlet.Default.useFileMappedBuffer", "false")
     context.setBaseResource(
       new ResourceCollection(
         webappResources.map(_.getPath).toArray


### PR DESCRIPTION
The value has been set "in hard" for now but a new SettingKey[Map[String, String]] could be created in future.
