### PR TITLE
Add a prototype AutoPlugin implementation

### DIFF
--- a/src/main/scala/plugin.scala
+++ b/src/main/scala/plugin.scala
@@ -2,32 +2,70 @@ package com.earldouglas.xwp
 
 import sbt._
 
+object Args {
+
+  def port(port: Int): Seq[String] =
+    if (port > 0) Seq("--port", port.toString) else Nil
+
+  def arg(key: String, value: String): Seq[String] =
+    if (value.length > 0) Seq(key, value) else Nil
+
+}
+
+object XwpJetty extends AutoPlugin {
+
+  import XwpPlugin._
+
+  override def requires = plugins.IvyPlugin
+
+  object autoImport {
+    val jettyLibs   = settingKey[Seq[ModuleID]]("jetty-libs")
+    val jettyMain   = settingKey[String]("jetty-main")
+    val jettyPort   = settingKey[Int]("jetty-port")
+    val jettyConfig = settingKey[String]("jetty-config")
+    val jettyArgs   = settingKey[Seq[String]]("jetty-args")
+   }
+  import autoImport._
+
+  val jettyRunner: ModuleID =
+    ("org.eclipse.jetty" % "jetty-runner" % "9.2.1.v20140609" % container.name).intransitive
+
+  override lazy val projectSettings: Seq[Setting[_]] =
+    XwpPlugin.jetty() ++
+    inConfig(container) {
+      Seq(
+        jettyLibs   := Seq(jettyRunner),
+        jettyMain   := "org.eclipse.jetty.runner.Runner",
+        jettyPort   := -1,
+        jettyConfig := "",
+        jettyArgs   := Nil,
+        launchCmd   := Seq(jettyMain.value) ++
+                       Args.port(jettyPort.value) ++
+                       Args.arg("--config", jettyConfig.value) ++
+                       jettyArgs.value :+
+                       (webappDest in webapp).value.getPath
+      )
+    }
+
+}
+
 object XwpPlugin extends Plugin
                     with WebappPlugin
                     with WarPlugin
                     with ContainerPlugin {
 
-  private def portArg(port: Int): Seq[String] =
-    if (port > 0) Seq("--port", port.toString) else Nil
-
-  private def arg(key: String, value: String): Seq[String] =
-    if (value.length > 0) Seq(key, value) else Nil
-
-  private val jettyRunner: ModuleID =
-    ("org.eclipse.jetty" % "jetty-runner" % "9.2.1.v20140609" % container.name).intransitive
-
   private val tomcatRunner: ModuleID =
     ("com.github.jsimone" % "webapp-runner" % "7.0.34.1" % container.name).intransitive
 
   def jetty(
-      libs: Seq[ModuleID] = Seq(jettyRunner)
+      libs: Seq[ModuleID] = Seq(XwpJetty.jettyRunner)
     , main: String      = "org.eclipse.jetty.runner.Runner"
     , port: Int         = -1
     , config: String    = ""
     , args: Seq[String] = Nil
     , options: ForkOptions = new ForkOptions
   ): Seq[Setting[_]] = {
-    val runnerArgs = Seq(main) ++ portArg(port) ++ arg("--config", config) ++ args
+    val runnerArgs = Seq(main) ++ Args.port(port) ++ Args.arg("--config", config) ++ args
     runnerContainer(libs, runnerArgs, options) ++ warSettings ++ webappSettings
   }
 
@@ -38,7 +76,7 @@ object XwpPlugin extends Plugin
     , args: Seq[String]   = Nil
     , options: ForkOptions = new ForkOptions
   ): Seq[Setting[_]] = {
-    val runnerArgs = Seq(main) ++ portArg(port) ++ args
+    val runnerArgs = Seq(main) ++ Args.port(port) ++ args
     runnerContainer(libs, runnerArgs, options) ++ warSettings ++ webappSettings
   }
 

--- a/src/sbt-test/xwp/auto-jetty-port-9090/build.sbt
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/build.sbt
@@ -1,0 +1,9 @@
+name := "test"
+
+version := "0.1.0-SNAPSHOT"
+
+libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"
+
+jettyPort in container := 9090
+
+enablePlugins(XwpJetty)

--- a/src/sbt-test/xwp/auto-jetty-port-9090/find-in-zip.sbt
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/find-in-zip.sbt
@@ -1,0 +1,10 @@
+val findInZip = InputKey[Unit]("find-in-zip")
+
+findInZip := {
+  val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+  val zipFile = new java.util.zip.ZipFile(args(0))
+  Option(zipFile.getEntry(args(1))) match {
+    case Some(_) => ()
+    case None => sys.error("File " + args(1) + " not found in zip " + args(0))
+  }
+}

--- a/src/sbt-test/xwp/auto-jetty-port-9090/http-get.sbt
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/http-get.sbt
@@ -1,0 +1,30 @@
+val get = inputKey[Unit]("get")
+
+get := {
+  def get(url: String, expect: Int, retries: Int): Unit = {
+    val status: Either[Exception,Int] =
+      try {
+        import java.net.URL
+        import java.net.HttpURLConnection
+        val conn = (new URL(url)).openConnection.asInstanceOf[HttpURLConnection]
+        conn.setInstanceFollowRedirects(false)
+        conn.setRequestMethod("GET")
+        conn.setDoOutput(false)
+        Right(conn.getResponseCode)
+      } catch {
+        case e: Exception => Left(e)
+      }
+    status match {
+      case Right(s) if s == expect => ()
+      case Right(s) =>
+        sys.error("Expected status " + expect + " but received " + s)
+      case Left(e) if retries > 0 =>
+        Thread.sleep(2000)
+        get(url, expect, retries - 1)
+      case Left(e) =>
+        sys.error("Caught exception " + e.toString)
+    }
+  }
+  val args: Seq[String] = complete.DefaultParsers.spaceDelimited("<arg>").parsed
+  get(args(0), args(1).toInt, 10)
+}

--- a/src/sbt-test/xwp/auto-jetty-port-9090/project/plugins.sbt
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/project/plugins.sbt
@@ -1,0 +1,10 @@
+Option(System.getProperty("plugin.version")) match {
+  case None =>
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Please specify this property using the SBT flag -D.""".stripMargin)
+  case Some(pluginVersion) =>
+    addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % pluginVersion)
+}
+
+scalacOptions ++= Seq("-feature", "-deprecation")

--- a/src/sbt-test/xwp/auto-jetty-port-9090/src/main/scala/servlets.scala
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/src/main/scala/servlets.scala
@@ -1,0 +1,14 @@
+package servlets
+
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class TestServlet extends HttpServlet {
+
+  override def doGet(req: HttpServletRequest, res: HttpServletResponse) {
+    res.setStatus(200)
+    res.getWriter.write("This is " + getClass.getName)
+  }
+
+}

--- a/src/sbt-test/xwp/auto-jetty-port-9090/src/main/webapp/WEB-INF/web.xml
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
+	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	      version="3.0">
+
+  <servlet>
+    <servlet-name>test</servlet-name>
+    <servlet-class>servlets.TestServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>test</servlet-name>
+    <url-pattern>/test</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>   
+    <servlet-name>default</servlet-name>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.png</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/src/sbt-test/xwp/auto-jetty-port-9090/src/main/webapp/index.html
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/src/main/webapp/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="styles/style.css">
+    <title>test</title>
+  </head>
+  <body>
+    <h1>test</h1>
+  </body>
+</html>

--- a/src/sbt-test/xwp/auto-jetty-port-9090/src/main/webapp/styles/style.css
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/src/main/webapp/styles/style.css
@@ -1,0 +1,1 @@
+h1 { border-bottom: 1px solid #666 }

--- a/src/sbt-test/xwp/auto-jetty-port-9090/test
+++ b/src/sbt-test/xwp/auto-jetty-port-9090/test
@@ -1,0 +1,6 @@
+> container:start
+-> get http://localhost:8080/index.html 200
+-> get http://localhost:8080/test 200
+> get http://localhost:9090/index.html 200
+> get http://localhost:9090/test 200
+> container:stop

--- a/src/sbt-test/xwp/auto-jetty/build.sbt
+++ b/src/sbt-test/xwp/auto-jetty/build.sbt
@@ -1,0 +1,7 @@
+name := "test"
+
+version := "0.1.0-SNAPSHOT"
+
+libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"
+
+enablePlugins(XwpJetty)

--- a/src/sbt-test/xwp/auto-jetty/find-in-zip.sbt
+++ b/src/sbt-test/xwp/auto-jetty/find-in-zip.sbt
@@ -1,0 +1,10 @@
+val findInZip = InputKey[Unit]("find-in-zip")
+
+findInZip := {
+  val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+  val zipFile = new java.util.zip.ZipFile(args(0))
+  Option(zipFile.getEntry(args(1))) match {
+    case Some(_) => ()
+    case None => sys.error("File " + args(1) + " not found in zip " + args(0))
+  }
+}

--- a/src/sbt-test/xwp/auto-jetty/http-get.sbt
+++ b/src/sbt-test/xwp/auto-jetty/http-get.sbt
@@ -1,0 +1,30 @@
+val get = inputKey[Unit]("get")
+
+get := {
+  def get(url: String, expect: Int, retries: Int): Unit = {
+    val status: Either[Exception,Int] =
+      try {
+        import java.net.URL
+        import java.net.HttpURLConnection
+        val conn = (new URL(url)).openConnection.asInstanceOf[HttpURLConnection]
+        conn.setInstanceFollowRedirects(false)
+        conn.setRequestMethod("GET")
+        conn.setDoOutput(false)
+        Right(conn.getResponseCode)
+      } catch {
+        case e: Exception => Left(e)
+      }
+    status match {
+      case Right(s) if s == expect => ()
+      case Right(s) =>
+        sys.error("Expected status " + expect + " but received " + s)
+      case Left(e) if retries > 0 =>
+        Thread.sleep(2000)
+        get(url, expect, retries - 1)
+      case Left(e) =>
+        sys.error("Caught exception " + e.toString)
+    }
+  }
+  val args: Seq[String] = complete.DefaultParsers.spaceDelimited("<arg>").parsed
+  get(args(0), args(1).toInt, 10)
+}

--- a/src/sbt-test/xwp/auto-jetty/project/plugins.sbt
+++ b/src/sbt-test/xwp/auto-jetty/project/plugins.sbt
@@ -1,0 +1,10 @@
+Option(System.getProperty("plugin.version")) match {
+  case None =>
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Please specify this property using the SBT flag -D.""".stripMargin)
+  case Some(pluginVersion) =>
+    addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % pluginVersion)
+}
+
+scalacOptions ++= Seq("-feature", "-deprecation")

--- a/src/sbt-test/xwp/auto-jetty/src/main/scala/servlets.scala
+++ b/src/sbt-test/xwp/auto-jetty/src/main/scala/servlets.scala
@@ -1,0 +1,14 @@
+package servlets
+
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class TestServlet extends HttpServlet {
+
+  override def doGet(req: HttpServletRequest, res: HttpServletResponse) {
+    res.setStatus(200)
+    res.getWriter.write("This is " + getClass.getName)
+  }
+
+}

--- a/src/sbt-test/xwp/auto-jetty/src/main/webapp/WEB-INF/web.xml
+++ b/src/sbt-test/xwp/auto-jetty/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
+	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	      version="3.0">
+
+  <servlet>
+    <servlet-name>test</servlet-name>
+    <servlet-class>servlets.TestServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>test</servlet-name>
+    <url-pattern>/test</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>   
+    <servlet-name>default</servlet-name>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.png</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/src/sbt-test/xwp/auto-jetty/src/main/webapp/index.html
+++ b/src/sbt-test/xwp/auto-jetty/src/main/webapp/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="styles/style.css">
+    <title>test</title>
+  </head>
+  <body>
+    <h1>test</h1>
+  </body>
+</html>

--- a/src/sbt-test/xwp/auto-jetty/src/main/webapp/styles/style.css
+++ b/src/sbt-test/xwp/auto-jetty/src/main/webapp/styles/style.css
@@ -1,0 +1,1 @@
+h1 { border-bottom: 1px solid #666 }

--- a/src/sbt-test/xwp/auto-jetty/test
+++ b/src/sbt-test/xwp/auto-jetty/test
@@ -1,0 +1,35 @@
+-> get http://localhost:8080/test 200
+-> get http://localhost:8080/index.html 200
+
+> container:start
+> get http://localhost:8080/test 200
+> get http://localhost:8080/index.html 200
+> get http://localhost:8080/index2.html 404
+
+$ copy-file src/main/webapp/index.html src/main/webapp/index2.html
+> get http://localhost:8080/index2.html 404
+
+> container:start
+> get http://localhost:8080/index2.html 200
+
+> container:stop
+-> get http://localhost:8080/test 200
+-> get http://localhost:8080/index.html 200
+-> get http://localhost:8080/index2.html 200
+
+> package
+$ exists target/webapp/index.html
+$ exists target/webapp/styles/style.css
+$ exists target/webapp/WEB-INF/web.xml
+$ absent target/webapp/WEB-INF/classes
+$ absent target/webapp/WEB-INF/lib/javax.servlet-api-3.0.1.jar
+$ exists target/webapp/WEB-INF/lib/test_2.10-0.1.0-SNAPSHOT.jar
+$ exists target/webapp/WEB-INF/lib/scala-library.jar
+$ exists target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war
+> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war META-INF/MANIFEST.MF
+> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war index.html
+> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war styles/style.css
+> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/web.xml
+-> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/javax.servlet-api-3.0.1.jar
+> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/test_2.10-0.1.0-SNAPSHOT.jar
+> find-in-zip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/scala-library.jar


### PR DESCRIPTION
Fixes #168
Fixes #204

This adds an initial version of an AutoPlugin for configuring a Jetty
container.  It includes support for the same options currently
available via arguments to `jetty()`, but now as individual sbt
settings.

**TODO:**

* [x] Update README.md (in v1.1 branch) with usage instructions and examples