### PR TITLE
Launcher cmd task

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
@@ -17,7 +17,7 @@ object ContainerPlugin extends AutoPlugin {
     val containerPort        = settingKey[Int]("port number to be used by container")
     val containerConfigFile  = settingKey[Option[File]]("path of container configuration file")
     val containerArgs        = settingKey[Seq[String]]("additional container args")
-    val containerLaunchCmd   = settingKey[Seq[String]]("command to launch container")
+    val containerLaunchCmd   = taskKey[Seq[String]]("command to launch container")
     val containerForkOptions = settingKey[ForkOptions]("fork options")
   }
 
@@ -47,7 +47,7 @@ object ContainerPlugin extends AutoPlugin {
       , stop               := stopTask.value
       , onLoad in Global   := onLoadSetting.value
       , javaOptions        := (javaOptions in Compile).value
-      , containerLaunchCmd := defaultLaunchCmd.value
+      , containerLaunchCmd <<= defaultLaunchCmd
       ))
 
   lazy val baseContainerSettings = Seq(
@@ -58,7 +58,7 @@ object ContainerPlugin extends AutoPlugin {
   , containerInstance    := new AtomicReference(Option.empty[Process])
   )
 
-  private def defaultLaunchCmd = Def.setting {
+  private def defaultLaunchCmd = Def.task {
     val portArg: Seq[String] = containerPort.value match {
       case p if p > 0 => Seq("--port", p.toString)
       case _ => Nil


### PR DESCRIPTION
I currently use a embedded tomcat container that supports accepting the webapp's dependency classpath as a argument, then mounts those entries in that classpath in the webapp using tomcat's resource API. While upgrading to xsbt-web-plugin 2.0, changing launchCmd from a task to setting prevents me from being able to pass the dependency classpath as argument in my project because settings cannot depend on tasks in SBT.