### PR TITLE
Set .war file as main artifact for WarPlugin

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/WarPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WarPlugin.scala
@@ -3,13 +3,9 @@ package com.earldouglas.xwp
 import sbt._, Keys._
 
 object WarPlugin extends AutoPlugin {
-  import Keys.{`package` => pkg}
-
   override def requires = WebappPlugin
 
   override lazy val projectSettings =
-    Defaults.packageTaskSettings(pkg, WebappPlugin.autoImport.webappPrepare) ++
-      Seq(artifact in pkg := Artifact(moduleName.value, "war", "war")) ++
-      addArtifact(artifact in (Compile, pkg), pkg)
-
+    Defaults.packageTaskSettings(packageBin, WebappPlugin.autoImport.webappPrepare) ++
+    Seq(artifact := Artifact(moduleName.value, "war", "war"))
 }


### PR DESCRIPTION
In addition make 'package' to be an alias for 'packageBin', as it is by default in sbt. It allows better interaction with other plugins if they accidentally or on purpose use 'packageBin' instead of 'package'. For example it is the case for aether-deploy plugin.
