### PR TITLE
Serving static resource directly in from sourceDirectory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,3 +15,4 @@ scriptedBufferLog  := false
 scriptedLaunchOpts <+= version { "-Dplugin.version=" + _ }
 watchSources       <++= sourceDirectory map { path => (path ** "*").get }
 
+version := "2.2.0"

--- a/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
@@ -23,7 +23,7 @@ object WebappPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] =
     Seq(
         sourceDirectory in webappPrepare := (sourceDirectory in Compile).value / "webapp"
-      , target in webappPrepare          := (target in Compile).value / "webapp"
+      , target in webappPrepare          := (sourceDirectory in Compile).value / "webapp"
       , webappPrepare                    := webappPrepareTask.value
       , webappPostProcess                := { _ => () }
       , webappWebInfClasses              := false
@@ -50,22 +50,22 @@ object WebappPlugin extends AutoPlugin {
       }).apply(in)
 
     val webappSrcDir = (sourceDirectory in webappPrepare).value
-    val webappTarget = (target in webappPrepare).value
+    val webappTarget = webappSrcDir
     val classpath = (fullClasspath in Runtime).value
     val webInfDir = webappTarget / "WEB-INF"
     val webappLibDir = webInfDir / "lib"
 
-    cacheify(
-      "webapp",
-      { in =>
-        for {
-          f <- Some(in)
-          if !f.isDirectory
-          r <- IO.relativizeFile(webappSrcDir, f)
-        } yield IO.resolve(webappTarget, r)
-      },
-      (webappSrcDir ** "*").get.toSet
-    )
+//    cacheify(
+//      "webapp",
+//      { in =>
+//        for {
+//          f <- Some(in)
+//          if !f.isDirectory
+//          r <- IO.relativizeFile(webappSrcDir, f)
+//        } yield IO.resolve(webappTarget, r)
+//      },
+//      (webappSrcDir ** "*").get.toSet
+//    )
 
     if (webappWebInfClasses.value) {
       // copy this project's classes directly to WEB-INF/classes

--- a/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
@@ -14,6 +14,7 @@ object WebappPlugin extends AutoPlugin {
     lazy val webappPrepare       = taskKey[Seq[(File, String)]]("prepare webapp contents for packaging")
     lazy val webappPostProcess   = taskKey[File => Unit]("additional task after preparing the webapp")
     lazy val webappWebInfClasses = settingKey[Boolean]("use WEB-INF/classes instead of WEB-INF/lib")
+    lazy val developmentMode     = settingKey[Boolean]("serve content directly from /src/main/webapp")
   }
 
   import autoImport._
@@ -23,10 +24,11 @@ object WebappPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] =
     Seq(
         sourceDirectory in webappPrepare := (sourceDirectory in Compile).value / "webapp"
-      , target in webappPrepare          := (sourceDirectory in Compile).value / "webapp"
+      , target in webappPrepare          := (target in Compile).value / "webapp"
       , webappPrepare                    := webappPrepareTask.value
       , webappPostProcess                := { _ => () }
       , webappWebInfClasses              := false
+      , developmentMode                  := false
       , watchSources                    ++= ((sourceDirectory in webappPrepare).value ** "*").get
     )
 
@@ -50,22 +52,29 @@ object WebappPlugin extends AutoPlugin {
       }).apply(in)
 
     val webappSrcDir = (sourceDirectory in webappPrepare).value
-    val webappTarget = webappSrcDir
+    val webappTarget = if (developmentMode.value){
+      webappSrcDir
+    } else {
+      (target in webappPrepare).value
+    }
+
     val classpath = (fullClasspath in Runtime).value
     val webInfDir = webappTarget / "WEB-INF"
     val webappLibDir = webInfDir / "lib"
 
-//    cacheify(
-//      "webapp",
-//      { in =>
-//        for {
-//          f <- Some(in)
-//          if !f.isDirectory
-//          r <- IO.relativizeFile(webappSrcDir, f)
-//        } yield IO.resolve(webappTarget, r)
-//      },
-//      (webappSrcDir ** "*").get.toSet
-//    )
+    if (!developmentMode.value) {
+      cacheify(
+        "webapp",
+        { in =>
+          for {
+            f <- Some(in)
+            if !f.isDirectory
+            r <- IO.relativizeFile(webappSrcDir, f)
+          } yield IO.resolve(webappTarget, r)
+        },
+        (webappSrcDir ** "*").get.toSet
+      )
+    }
 
     if (webappWebInfClasses.value) {
       // copy this project's classes directly to WEB-INF/classes
@@ -121,7 +130,11 @@ object WebappPlugin extends AutoPlugin {
       }
     )
 
-    webappPostProcess.value(webappTarget)
+    if (developmentMode.value) {
+      streams.value.log.info("starting server in development mode, postProcess not available!")
+    } else {
+      webappPostProcess.value(webappTarget)
+    }
 
     (webappTarget ** "*") pair (relativeTo(webappTarget) | flat)
   }


### PR DESCRIPTION
Continuation of issue https://github.com/earldouglas/xsbt-web-plugin/issues/298
- [x] static content does not need restart to be refreshed
- [x] configurable deployment with/without direct file access

To enable development mode:

``` scala
...
target in webappPrepare := (sourceDirectory in Compile).value / "webapp",
watchSources := watchSources.value.filterNot { x =>
   x.isDirectory || x.getAbsolutePath.contains("webapp")
}
```

