### PR TITLE
Throw an exception if sbt version is < 0.13.6

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
@@ -110,10 +110,12 @@ object ContainerPlugin extends AutoPlugin {
 
   private def validateSbtVerison(version: String): Unit = {
     val versionArray = version.split("\\.").map(_.toInt)
+    val major = versionArray(0)
     val minor = versionArray(1)
     val patch = versionArray(2)
 
-    if ((minor < 13) || (minor == 13 && patch < 6)) {
+    if ((major == 0 && minor < 13) ||
+        (major == 0 && minor == 13 && patch < 6)) {
       throw new RuntimeException(
          "xsbt-web-plugin requires sbt 0.13.6+, " +
          "but this project is configured to use sbt " +

--- a/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
@@ -108,8 +108,23 @@ object ContainerPlugin extends AutoPlugin {
     shutdown(streams.value.log, containerInstance.value)
   }
 
+  private def validateSbtVerison(version: String): Unit = {
+    val versionArray = version.split("\\.").map(_.toInt)
+    val minor = versionArray(1)
+    val patch = versionArray(2)
+
+    if ((minor < 13) || (minor == 13 && patch < 6)) {
+      throw new RuntimeException(
+         "xsbt-web-plugin requires sbt 0.13.6+, " +
+         "but this project is configured to use sbt " +
+         version
+      )
+    }
+  }
+
   private def onLoadSetting: Def.Initialize[State => State] = Def.setting {
     (onLoad in Global).value compose { state: State =>
+      validateSbtVerison(state.configuration.provider.id.version)
       if ((containerShutdownOnExit).value) {
         state.addExitHook(shutdown(state.log, containerInstance.value))
       } else {


### PR DESCRIPTION
xsbt-web-plugin uses sbt APIs from 0.13.6 (`AutoPlugin`,
`enablePlubins`, etc.).

This change will cause xsbt-web-plugin to throw an exception if it is
used with an incompatible version of sbt.

Fixes #303