### PR TITLE
Add a `debug` container command

### DIFF
--- a/src/sbt-test/container/debug/build.sbt
+++ b/src/sbt-test/container/debug/build.sbt
@@ -1,0 +1,11 @@
+name := "test"
+
+version := "0.1.0-SNAPSHOT"
+
+libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"
+
+enablePlugins(JettyPlugin)
+
+containerLibs in Jetty := Seq("org.eclipse.jetty" % "jetty-runner" % "9.2.1.v20140609" intransitive())
+
+containerMain in Jetty := "org.eclipse.jetty.runner.Runner"

--- a/src/sbt-test/container/debug/http-get.sbt
+++ b/src/sbt-test/container/debug/http-get.sbt
@@ -1,0 +1,30 @@
+val get = inputKey[Unit]("get")
+
+get := {
+  def get(url: String, expect: Int, retries: Int): Unit = {
+    val status: Either[Exception,Int] =
+      try {
+        import java.net.URL
+        import java.net.HttpURLConnection
+        val conn = (new URL(url)).openConnection.asInstanceOf[HttpURLConnection]
+        conn.setInstanceFollowRedirects(false)
+        conn.setRequestMethod("GET")
+        conn.setDoOutput(false)
+        Right(conn.getResponseCode)
+      } catch {
+        case e: Exception => Left(e)
+      }
+    status match {
+      case Right(s) if s == expect => ()
+      case Right(s) =>
+        sys.error("Expected status " + expect + " but received " + s)
+      case Left(e) if retries > 0 =>
+        Thread.sleep(2000)
+        get(url, expect, retries - 1)
+      case Left(e) =>
+        sys.error("Caught exception " + e.toString)
+    }
+  }
+  val args: Seq[String] = complete.DefaultParsers.spaceDelimited("<arg>").parsed
+  get(args(0), args(1).toInt, 10)
+}

--- a/src/sbt-test/container/debug/project/plugins.sbt
+++ b/src/sbt-test/container/debug/project/plugins.sbt
@@ -1,0 +1,10 @@
+Option(System.getProperty("plugin.version")) match {
+  case None =>
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Please specify this property using the SBT flag -D.""".stripMargin)
+  case Some(pluginVersion) =>
+    addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % pluginVersion)
+}
+
+scalacOptions ++= Seq("-feature", "-deprecation")

--- a/src/sbt-test/container/debug/src/main/scala/servlets.scala
+++ b/src/sbt-test/container/debug/src/main/scala/servlets.scala
@@ -1,0 +1,14 @@
+package servlets
+
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class TestServlet extends HttpServlet {
+
+  override def doGet(req: HttpServletRequest, res: HttpServletResponse) {
+    res.setStatus(200)
+    res.getWriter.write("This is " + getClass.getName)
+  }
+
+}

--- a/src/sbt-test/container/debug/src/main/webapp/WEB-INF/web.xml
+++ b/src/sbt-test/container/debug/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
+	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	      version="3.0">
+
+  <servlet>
+    <servlet-name>test</servlet-name>
+    <servlet-class>servlets.TestServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>test</servlet-name>
+    <url-pattern>/test</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>   
+    <servlet-name>default</servlet-name>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.png</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/src/sbt-test/container/debug/src/main/webapp/index.html
+++ b/src/sbt-test/container/debug/src/main/webapp/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="styles/style.css">
+    <title>test</title>
+  </head>
+  <body>
+    <h1>test</h1>
+  </body>
+</html>

--- a/src/sbt-test/container/debug/src/main/webapp/styles/style.css
+++ b/src/sbt-test/container/debug/src/main/webapp/styles/style.css
@@ -1,0 +1,1 @@
+h1 { border-bottom: 1px solid #666 }

--- a/src/sbt-test/container/debug/test
+++ b/src/sbt-test/container/debug/test
@@ -1,0 +1,18 @@
+-> get http://localhost:8080/test 200
+-> get http://localhost:8080/index.html 200
+
+> jetty:debug
+> get http://localhost:8080/test 200
+> get http://localhost:8080/index.html 200
+> get http://localhost:8080/index2.html 404
+
+$ copy-file src/main/webapp/index.html src/main/webapp/index2.html
+> get http://localhost:8080/index2.html 404
+
+> jetty:debug
+> get http://localhost:8080/index2.html 200
+
+> jetty:stop
+-> get http://localhost:8080/test 200
+-> get http://localhost:8080/index.html 200
+-> get http://localhost:8080/index2.html 200


### PR DESCRIPTION
This adds `tomcat:debug` and `jetty:debug`, which launch the container
with the arguments set in `debugOptions`, which defaults to:

```scala
Seq(
    "-Xdebug"
  , "-Xrunjdwp:transport=dt_socket,address=8888,server=y,suspend=n"
)
```

Relevant docs:

* https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/introclientissues005.html
* http://docs.oracle.com/javase/1.5.0/docs/guide/jpda/conninv.html

Fixes #301