### PR TITLE
sbt.BuildExtra#seq is deprecated

### DIFF
--- a/docs/2.2.md
+++ b/docs/2.2.md
@@ -510,7 +510,7 @@ Add the following lines to *build.sbt*, making sure to specify the
 correct path to JRebel:
 
 ```scala
-seq(jrebelSettings: _*)
+jrebelSettings
 
 jrebel.webLinks += (sourceDirectory in Compile).value / "webapp"
 


### PR DESCRIPTION
- https://github.com/sbt/sbt/blob/v0.13.13/main/src/main/scala/sbt/Defaults.scala#L2030-L2031
- https://github.com/sbt/sbt/commit/61509408c9bbc0581bb5c41c0b69c19402cb1fb8