### PR TITLE
specify scalaVersion in scripted tests

### DIFF
--- a/src/sbt-test/container/multi-module-multi-webapp/build.sbt
+++ b/src/sbt-test/container/multi-module-multi-webapp/build.sbt
@@ -1,11 +1,20 @@
 organization := "test"
 
-lazy val root = (project in file(".")) aggregate(maths, mathsweb, remote, remoteweb)
+val commonSettings = Seq(
+  scalaVersion := "2.10.6"
+)
+
+lazy val root = (project in file(".")).aggregate(maths, mathsweb, remote, remoteweb)
+  .settings(commonSettings: _*)
 
 lazy val maths = project
+  .settings(commonSettings: _*)
 
 lazy val remote = project
+  .settings(commonSettings: _*)
 
-lazy val remoteweb = project dependsOn (remote)
+lazy val remoteweb = project.dependsOn(remote)
+  .settings(commonSettings: _*)
 
-lazy val mathsweb = project dependsOn (maths)
+lazy val mathsweb = project.dependsOn(maths)
+  .settings(commonSettings: _*)

--- a/src/sbt-test/container/multi-module-single-webapp/build.sbt
+++ b/src/sbt-test/container/multi-module-single-webapp/build.sbt
@@ -1,11 +1,20 @@
 organization := "test"
 
-lazy val root = (project in file(".")) aggregate(numbers, maths, mathsweb, typeclasses)
+val commonSettings = Seq(
+  scalaVersion := "2.10.6"
+)
+
+lazy val root = (project in file(".")).aggregate(numbers, maths, mathsweb, typeclasses)
+  .settings(commonSettings: _*)
 
 lazy val numbers = project
+  .settings(commonSettings: _*)
 
-lazy val maths = project dependsOn numbers
+lazy val maths = project.dependsOn(numbers)
+  .settings(commonSettings: _*)
 
 lazy val typeclasses = project
+  .settings(commonSettings: _*)
 
-lazy val mathsweb = project dependsOn (maths, typeclasses)
+lazy val mathsweb = project.dependsOn(maths, typeclasses)
+  .settings(commonSettings: _*)

--- a/src/sbt-test/war/inherit/build.sbt
+++ b/src/sbt-test/war/inherit/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"

--- a/src/sbt-test/war/simple/build.sbt
+++ b/src/sbt-test/war/simple/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"

--- a/src/sbt-test/war/simple/test
+++ b/src/sbt-test/war/simple/test
@@ -5,7 +5,7 @@ $ exists target/webapp/WEB-INF/web.xml
 $ absent target/webapp/WEB-INF/classes
 $ absent target/webapp/WEB-INF/lib/javax.servlet-api-3.0.1.jar
 $ exists target/webapp/WEB-INF/lib/test_2.10-0.1.0-SNAPSHOT.jar
-$ exists target/webapp/WEB-INF/lib/scala-library.jar
+$ exists target/webapp/WEB-INF/lib/scala-library-2.10.6.jar
 
 > clean
 $ absent target/webapp
@@ -18,4 +18,4 @@ $ exists target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war
 > findInZip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/web.xml
 -> findInZip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/javax.servlet-api-3.0.1.jar
 > findInZip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/test_2.10-0.1.0-SNAPSHOT.jar
-> findInZip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/scala-library.jar
+> findInZip target/scala-2.10/test_2.10-0.1.0-SNAPSHOT.war WEB-INF/lib/scala-library-2.10.6.jar

--- a/src/sbt-test/webapp/unmanaged-resources/build.sbt
+++ b/src/sbt-test/webapp/unmanaged-resources/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 unmanagedResourceDirectories in Compile += (sourceDirectory in Compile).value / "extra"

--- a/src/sbt-test/webapp/unmanaged-sources/build.sbt
+++ b/src/sbt-test/webapp/unmanaged-sources/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / "extra"

--- a/src/sbt-test/webapp/web-inf-lib/build.sbt
+++ b/src/sbt-test/webapp/web-inf-lib/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 enablePlugins(WebappPlugin)

--- a/src/sbt-test/webapp/webapp-dest/build.sbt
+++ b/src/sbt-test/webapp/webapp-dest/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 enablePlugins(WebappPlugin)

--- a/src/sbt-test/webapp/webapp-src/build.sbt
+++ b/src/sbt-test/webapp/webapp-src/build.sbt
@@ -1,5 +1,7 @@
 name := "test"
 
+scalaVersion := "2.10.6"
+
 version := "0.1.0-SNAPSHOT"
 
 enablePlugins(WebappPlugin)


### PR DESCRIPTION
This is prepare for sbt 1.0 cross build because default scalaVersion is 2.12 since sbt 1.0.