### PR TITLE
Updates jetty-runner to 9.4.8.v20171121

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
@@ -17,7 +17,7 @@ object JettyPlugin extends AutoPlugin {
 
   override val projectConfigurations = Seq(Jetty)
 
-  val jettyRunner = "org.eclipse.jetty" % "jetty-runner" % "9.4.6.v20170531"
+  val jettyRunner = "org.eclipse.jetty" % "jetty-runner" % "9.4.8.v20171121"
 
   override lazy val projectSettings =
     ContainerPlugin.containerSettings(Jetty) ++


### PR DESCRIPTION
Without this, users will encounter an error about `module-info.class` when using jars compiled on JDK9.

See https://github.com/eclipse/jetty.project/issues/1692 for more information

Fixes #361 

Once merged, https://github.com/scalatra/sbt-scalatra/issues/55 could be addressed.
