### PR TITLE
Add support for webappPostProcess to quickstart

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
@@ -38,6 +38,7 @@ object ContainerPlugin extends AutoPlugin {
     settingKey[AtomicReference[Seq[Process]]]("current container process")
 
   import WebappPlugin.autoImport.webappPrepare
+  import WebappPlugin.autoImport.webappPrepareQuick
   import autoImport._
 
   override def requires = WarPlugin
@@ -56,7 +57,7 @@ object ContainerPlugin extends AutoPlugin {
       Seq(libraryDependencies ++= (containerLibs in conf).value.map(_ % conf)) ++
       inConfig(conf)(Seq(
         start              := (startTask dependsOn webappPrepare).value
-      , quickstart         := quickstartTask.value
+      , quickstart         := (quickstartTask dependsOn webappPrepareQuick).value
       , debug              := (debugTask dependsOn webappPrepare).value
       , join               := joinTask.value
       , stop               := stopTask.value
@@ -118,8 +119,11 @@ object ContainerPlugin extends AutoPlugin {
         Classpaths.managedJars(conf, classpathTypes.value, update.value).map(_.data)
 
       val path = {
-        if (quick) sourceDirectory in webappPrepare
-        else target in webappPrepare
+        if (quick) {
+          target in webappPrepareQuick
+        } else {
+          target in webappPrepare
+        }
       }.value.absolutePath
 
       def launchFn(_containerPort: Int, _debugPort: Int): Process = {

--- a/src/sbt-test/webapp/combined/test
+++ b/src/sbt-test/webapp/combined/test
@@ -81,6 +81,10 @@ $ copy-file sbt/yuicompressor.sbt yuicompressor.sbt
 $ copy-file sbt/project/yuicompressor.sbt project/yuicompressor.sbt
 > reload
 > clean
+$ absent target/webapp-quick/script-min.js
+> webappPrepareQuick
+$ exists target/webapp-quick/script-min.js
+$ absent target/webapp/script-min.js
 > webappPrepare
 $ exists target/webapp/script-min.js
 $ delete yuicompressor.sbt


### PR DESCRIPTION
This adds a new `webappPrepareQuick` task used by `quickstart` to copy
webapp sources from `sourceDirectory in webappPrepare` to
`target/webapp-quick`, and then run `webappPostProcess` on it.

The two target directories `target/webapp-quick` and `target/webapp` are
kept separate so that artifacts from `quickstart` and `start` don't
interfere with each other.

Fixes #373