### PR TITLE
Add pull request trigger for CI build

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This changes the GitHub Actions configuration to enable builds for pull
requests, so that PRs from forked repos trigger CI builds.

See [configuring workflow events][1] in the GitHub docs for details on
build triggers.

[1]: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#configuring-workflow-events
