### PR TITLE
Set project names for some scripted tests

### DIFF
--- a/src/sbt-test/examples/scala-js/build.sbt
+++ b/src/sbt-test/examples/scala-js/build.sbt
@@ -1,3 +1,5 @@
+name := "scala-js"
+
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
 
 enablePlugins(JettyPlugin)

--- a/src/sbt-test/war/combined/build.sbt
+++ b/src/sbt-test/war/combined/build.sbt
@@ -1,3 +1,5 @@
+name := "combined"
+
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
 
 enablePlugins(WarPlugin)

--- a/src/sbt-test/webapp/combined/build.sbt
+++ b/src/sbt-test/webapp/combined/build.sbt
@@ -1,1 +1,3 @@
+name := "combined"
+
 enablePlugins(WebappPlugin)


### PR DESCRIPTION
sbt 1.4.x no longer uses the source directory name for scripted test
project names, which are in turn used for path-based verification of
artifacts by the following scripted tests:

* `examples/scala-js`
* `war/combined`
* `webapp/combined`

This change sets project names for these, allowing #423 to be merged.