### PR TITLE
Check for missing files in cache

### DIFF
--- a/src/sbt-test/webapp/combined/test
+++ b/src/sbt-test/webapp/combined/test
@@ -9,6 +9,16 @@ $ copy-file changes/index2.html src/main/webapp/index2.html
 > webappPrepare
 $ exists target/webapp/index2.html
 
+########################################################################
+# https://github.com/earldouglas/xsbt-web-plugin/issues/376
+
+$ delete target/webapp/index2.html
+$ absent target/webapp/index2.html
+> webappPrepare
+$ exists target/webapp/index2.html
+
+########################################################################
+
 $ delete src/main/webapp/index2.html
 > webappPrepare
 $ absent target/webapp/index2.html


### PR DESCRIPTION
This modifies the `cacheify` function to include not just new and
modified files, but missing target files as well.  With this change,
external deletion/modification of target files will be recreated from
source by `webappPrepare` and `webappPrepareQuick`.

Fixes #376