### PR TITLE
Update to the non-deprecated `IO#jar`

### DIFF
--- a/src/main/scala-sbt-0.13/com/earldouglas/xwp/Compat.scala
+++ b/src/main/scala-sbt-0.13/com/earldouglas/xwp/Compat.scala
@@ -16,4 +16,10 @@ object Compat {
 
   def cached(cacheBaseDirectory: File, inStyle: Style, outStyle: Style)(action: (ChangeReport[File], ChangeReport[File]) => Set[File]): Set[File] => Set[File] = 
     FileFunction.cached(cacheBaseDirectory = cacheBaseDirectory)(inStyle = inStyle, outStyle = outStyle)(action = action)
+
+  def jar(sources: Traversable[(File, String)], outputJar: File, manifest: java.util.jar.Manifest): Unit =
+    IO.jar( sources = sources
+          , outputJar = outputJar
+          , manifest = manifest
+          )
 }

--- a/src/main/scala-sbt-1.0/com/earldouglas/xwp/Compat.scala
+++ b/src/main/scala-sbt-1.0/com/earldouglas/xwp/Compat.scala
@@ -18,4 +18,11 @@ object Compat {
 
   def cached(cacheBaseDirectory: File, inStyle: Style, outStyle: Style)(action: (ChangeReport[File], ChangeReport[File]) => Set[File]): Set[File] => Set[File] = 
     sbt.util.FileFunction.cached(CacheStoreFactory(cacheBaseDirectory), inStyle = inStyle, outStyle = outStyle)(action = action)
+
+  def jar(sources: Traversable[(File, String)], outputJar: File, manifest: java.util.jar.Manifest): Unit =
+    io.IO.jar( sources = sources
+             , outputJar = outputJar
+             , manifest = manifest
+             , time = None
+             )
 }

--- a/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
@@ -172,7 +172,10 @@ object WebappPlugin extends AutoPlugin {
             None
         }
         jarFile    = cpArt.name + ".jar"
-        _          = IO.jar(files, webappLibDir / jarFile, new Manifest)
+        _          = Compat.jar( sources = files
+                               , outputJar = webappLibDir / jarFile
+                               , manifest = new Manifest
+                               )
       } yield ()
 
       // copy this project's library dependency .jar files to WEB-INF/lib


### PR DESCRIPTION
This uses `Compat` for delegation to the different sbt APIs, and fixes
the compile-time error message:

```
[warn] WebappPlugin.scala:175:25: method jar in object IO is deprecated (since 1.3.2): Please specify whether to use a static timestamp
[warn]         _          = IO.jar(files, webappLibDir / jarFile, new Manifest)
[warn]                         ^
```

Fixes #441