### PR TITLE
Constrain webapp libs to dependencyClasspath

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
@@ -154,7 +154,7 @@ object WebappPlugin extends AutoPlugin {
                 )
       }
 
-      val classpath = (fullClasspath in Runtime).value
+      val classpath = (dependencyClasspath in Runtime).value
 
       // create .jar files for depended-on projects in WEB-INF/lib
       for {


### PR DESCRIPTION
The *.jar* files bound for *webapp/WEB-INF/lib* only need to come from
directories and files in `dependencyClasspath`.  This updates
`webappPrepareTask` accordingly.