### PR TITLE
Use the webapp path provided to containerLaunchCmd

### DIFF
--- a/src/sbt-test/examples/payara-micro/build.sbt
+++ b/src/sbt-test/examples/payara-micro/build.sbt
@@ -7,5 +7,5 @@ containerLibs in Container :=
   Seq("fish.payara.extras" % "payara-micro" % "5.2020.3")
 
 containerLaunchCmd in Container := { (port, path) =>
-  Seq("fish.payara.micro.PayaraMicro", "--deploy", "target/webapp", "--contextroot", "/")
+  Seq("fish.payara.micro.PayaraMicro", "--deploy", path, "--contextroot", "/")
 }


### PR DESCRIPTION
This updates the Payara Micro test to use the webapp path provided as an
argument to `containerLaunchCmd`.  The value of `path` is an absolute
path to either *target/webapp* or *target/webapp-quick*, depending on
whether `container:test` or `container:quicktest` is used.

This is largely a noop as `container:quicktest` fails, possibly because
Payara Micro uses a separate classloader for the webapp than for the
forked JVM.