### PR TITLE
Add a CI step to manually test reqs/min

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,4 +14,5 @@ jobs:
         java-version: 8
     - run: sbt ^test
     - run: sbt ^publishLocal
+    - run: sbt scripted
     - run: cd src/sbt-test/reqs/min && sbt jetty:test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,4 +14,4 @@ jobs:
         java-version: 8
     - run: sbt ^test
     - run: sbt ^publishLocal
-    - run: sbt scripted
+    - run: cd src/sbt-test/reqs/min && sbt jetty:test

--- a/src/sbt-test/reqs/min/build.sbt
+++ b/src/sbt-test/reqs/min/build.sbt
@@ -1,6 +1,7 @@
 scalaVersion := "2.10.2"
 
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % "test"
 
 enablePlugins(JettyPlugin)


### PR DESCRIPTION
Since the current version of sbt [is not keen][1] to run scripted tests
using sbt 0.13.6, we need to manually run it after `sbt scripted` skips
it.

This changes the GitHub Actions configuration to manually run 
`sbt jetty:test` under *reqs/min* after the rest of the scripted tests
pass.

Fixes #437

[1]: https://github.com/earldouglas/xsbt-web-plugin/runs/1907163904?check_suite_focus=true#step:6:42
