### PR TITLE
Switch from ScalaTest to JUnit for portability

### DIFF
--- a/src/reqs/build.sbt
+++ b/src/reqs/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % "test"
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 
 enablePlugins(JettyPlugin)

--- a/src/reqs/src/main/scala/GettingStartedServlet.scala
+++ b/src/reqs/src/main/scala/GettingStartedServlet.scala
@@ -6,7 +6,7 @@ class GettingStartedServlet extends HttpServlet {
 
   override def doGet( req: HttpServletRequest
                     , res: HttpServletResponse
-                    ) {
+                    ): Unit = {
 
     res.setContentType("text/html")
     res.setCharacterEncoding("UTF-8")

--- a/src/reqs/src/main/scala/GettingStartedServlet.scala
+++ b/src/reqs/src/main/scala/GettingStartedServlet.scala
@@ -6,7 +6,7 @@ class GettingStartedServlet extends HttpServlet {
 
   override def doGet( req: HttpServletRequest
                     , res: HttpServletResponse
-                    ): Unit = {
+                    ) {
 
     res.setContentType("text/html")
     res.setCharacterEncoding("UTF-8")

--- a/src/reqs/src/test/scala/TestSuite.scala
+++ b/src/reqs/src/test/scala/TestSuite.scala
@@ -1,16 +1,21 @@
-import org.scalatest._
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
-class TestSuite extends FunSuite with Matchers {
+class TestSuite {
 
-  test("/") {
-    Request("GET", "http://localhost:8080/", Map.empty, None) shouldBe
-      Response(200, Map("Content-Type" -> "text/html;charset=utf-8"),
-        body = 
-          """|<html>
-             |  <body>
-             |    <h1>Hello, world!</h1>
-             |  </body>
-             |</html>""".stripMargin
-      )
+  @Test
+  def getRoot(): Unit = {
+    assertEquals(
+        Response( 200
+                , Map("Content-Type" -> "text/html;charset=utf-8")
+                , body =
+                    """|<html>
+                       |  <body>
+                       |    <h1>Hello, world!</h1>
+                       |  </body>
+                       |</html>""".stripMargin
+                )
+      , Request("GET", "http://localhost:8080/", Map.empty, None)
+    )
   }
 }


### PR DESCRIPTION
A given version of ScalaTest isn't always available across different
versions of Scala.  This replaces it with JUnit, which is independent of
the Scala (or sbt) version.  Since the test case is so simple for reqs
checks, we can get away with just using JUnit.