### PR TITLE
Expand reqs check across sbt and scala ranges

### DIFF
--- a/src/reqs/check.sh
+++ b/src/reqs/check.sh
@@ -5,6 +5,20 @@ set -e
 pushd `dirname $0`
 
 function test() {
+  SCALA_VERSION=2.10.2 _test
+  SCALA_VERSION=2.10.7 _test
+
+  SCALA_VERSION=2.11.0 _test
+  SCALA_VERSION=2.11.12 _test
+
+  SCALA_VERSION=2.12.0 _test
+  SCALA_VERSION=2.12.13 _test
+
+  SCALA_VERSION=2.13.0 _test
+  SCALA_VERSION=2.13.6 _test
+}
+
+function _test() {
   TMP_SRC_DIR=`mktemp -d`
   cp -rf . $TMP_SRC_DIR
 
@@ -25,10 +39,33 @@ function test() {
   popd
 }
 
-SCALA_VERSION=2.10.2 SBT_VERSION=0.13.6 SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.6/sbt-launch.jar test
-SCALA_VERSION=2.10.2 SBT_VERSION=0.13.18 SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.18/sbt-launch.jar test
-SCALA_VERSION=2.13.4 SBT_VERSION=1.3.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.0/sbt-launch-1.3.0.jar test
-SCALA_VERSION=2.13.4 SBT_VERSION=1.5.2 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.2/sbt-launch-1.5.2.jar test
-SCALA_VERSION=3.0.0 SBT_VERSION=1.5.2 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.2/sbt-launch-1.5.2.jar test
+
+# sbt 0.13
+SBT_VERSION=0.13.6 SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.6/sbt-launch.jar test
+SBT_VERSION=0.13.18 SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.18/sbt-launch.jar test
+
+# sbt 1.0
+SBT_VERSION=1.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.0.0/sbt-launch-1.0.0.jar test
+SBT_VERSION=1.0.4 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.0.4/sbt-launch-1.0.4.jar test
+
+# sbt 1.1
+SBT_VERSION=1.1.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.1.0/sbt-launch-1.1.0.jar test
+SBT_VERSION=1.1.6 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.1.6/sbt-launch-1.1.6.jar test
+
+# sbt 1.2
+SBT_VERSION=1.2.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.2.0/sbt-launch-1.2.0.jar test
+SBT_VERSION=1.2.8 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.2.8/sbt-launch-1.2.8.jar test
+
+# sbt 1.3
+SBT_VERSION=1.3.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.0/sbt-launch-1.3.0.jar test
+SBT_VERSION=1.3.13 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.13/sbt-launch-1.3.13.jar test
+
+# sbt 1.4
+SBT_VERSION=1.4.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.0/sbt-launch-1.4.0.jar test
+SBT_VERSION=1.4.9 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.9/sbt-launch-1.4.9.jar test
+
+# sbt 1.5 (note Scala 3 support was introduced in sbt 1.5.0)
+SBT_VERSION=1.5.0 SCALA_VERSION=3.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar _test
+SBT_VERSION=1.5.2 SCALA_VERSION=3.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.2/sbt-launch-1.5.2.jar _test
 
 popd

--- a/src/reqs/check.sh
+++ b/src/reqs/check.sh
@@ -5,17 +5,13 @@ set -e
 pushd `dirname $0`
 
 function test() {
-  SCALA_VERSION=2.10.2 _test
-  SCALA_VERSION=2.10.7 _test
-
-  SCALA_VERSION=2.11.0 _test
-  SCALA_VERSION=2.11.12 _test
-
-  SCALA_VERSION=2.12.0 _test
-  SCALA_VERSION=2.12.13 _test
-
-  SCALA_VERSION=2.13.0 _test
-  SCALA_VERSION=2.13.6 _test
+  # Note Scala 2.12.0 is not supported:
+  # /tmp/sbt_10cf059/scala/ZincCompat.scala:19: error: type PlainNioFile is not a member of package scala.reflect.io
+  #   type PlainNioFile = scala.reflect.io.PlainNioFile
+  for SCALA_VERSION in 2.10.2 2.10.7 2.11.0 2.11.12 2.12.1 2.12.13 2.13.0 2.13.6
+  do
+    _test
+  done
 }
 
 function _test() {
@@ -39,33 +35,30 @@ function _test() {
   popd
 }
 
-
 # sbt 0.13
-SBT_VERSION=0.13.6 SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.6/sbt-launch.jar test
-SBT_VERSION=0.13.18 SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.18/sbt-launch.jar test
+for SBT_VERSION in 0.13.6 0.13.18
+do
+  SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar
+  test
+done
 
-# sbt 1.0
-SBT_VERSION=1.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.0.0/sbt-launch-1.0.0.jar test
-SBT_VERSION=1.0.4 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.0.4/sbt-launch-1.0.4.jar test
+# Note sbt versions 1.0-1.2 are not supported:
+# [error] java.lang.NoClassDefFoundError: sbt/State$StateOpsImpl$
+# [error]         at com.earldouglas.xwp.ContainerPlugin$.$anonfun$onLoadSetting$2(ContainerPlugin.scala:178)
 
-# sbt 1.1
-SBT_VERSION=1.1.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.1.0/sbt-launch-1.1.0.jar test
-SBT_VERSION=1.1.6 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.1.6/sbt-launch-1.1.6.jar test
+# sbt 1.3, 1.4
+for SBT_VERSION in 1.3.0 1.3.13 1.4.0 1.4.9
+do
+  SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch-$SBT_VERSION.jar
+  test
+done
 
-# sbt 1.2
-SBT_VERSION=1.2.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.2.0/sbt-launch-1.2.0.jar test
-SBT_VERSION=1.2.8 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.2.8/sbt-launch-1.2.8.jar test
-
-# sbt 1.3
-SBT_VERSION=1.3.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.0/sbt-launch-1.3.0.jar test
-SBT_VERSION=1.3.13 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.13/sbt-launch-1.3.13.jar test
-
-# sbt 1.4
-SBT_VERSION=1.4.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.0/sbt-launch-1.4.0.jar test
-SBT_VERSION=1.4.9 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.9/sbt-launch-1.4.9.jar test
-
-# sbt 1.5 (note Scala 3 support was introduced in sbt 1.5.0)
-SBT_VERSION=1.5.0 SCALA_VERSION=3.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar _test
-SBT_VERSION=1.5.2 SCALA_VERSION=3.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.2/sbt-launch-1.5.2.jar _test
+# sbt 1.5
+# Scala 3 support was introduced in sbt 1.5.0
+for SBT_VERSION in 1.5.0 1.5.2
+do
+  SCALA_VERSION=3.0.0 SBT_LAUNCH=https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch-$SBT_VERSION.jar
+  _test
+done
 
 popd


### PR DESCRIPTION
This expands reqs support checks across combinations of ranges of sbt
and Scala.

* sbt: 0.13.6 - 1.5.2
* Scala: 2.10.2 - 3.0.0