### PR TITLE
Update default jetty-runner to 9.4.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ port =>
 
 By default, [Jetty
 Runner](https://www.eclipse.org/jetty/documentation/current/runner.html)
-9.4.34 is used.  To use a different version, set
+9.4.42 is used.  To use a different version, set
 `containerLibs`:
 
 ```scala

--- a/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
@@ -18,7 +18,7 @@ object JettyPlugin extends AutoPlugin {
   override val projectConfigurations = Seq(Jetty)
 
   val jettyRunner =
-    "org.eclipse.jetty" % "jetty-runner" % "9.4.34.v20201102"
+    "org.eclipse.jetty" % "jetty-runner" % "9.4.42.v20210604"
 
   override lazy val projectSettings =
     ContainerPlugin.containerSettings(Jetty) ++

--- a/src/sbt-test/container/combined/test
+++ b/src/sbt-test/container/combined/test
@@ -96,7 +96,7 @@ $ copy-file sbt/jetty.sbt jetty.sbt
 ## jetty 9
 
 > reload
-> 'set containerLibs in Jetty := Seq("org.eclipse.jetty" % "jetty-runner" % "9.3.13.v20161014" intransitive())'
+> 'set containerLibs in Jetty := Seq("org.eclipse.jetty" % "jetty-runner" % "9.4.42.v20210604" intransitive())'
 > 'set containerMain in Jetty := "org.eclipse.jetty.runner.Runner"'
 > jetty:start
 > await 8080


### PR DESCRIPTION
This also updates the `container/combined` test to use jetty-runner
9.4.42.

See https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/

We can't use versions 10 or 11 yet because they're both built with JDK
11, while we're still on JDK 8:

* https://github.com/eclipse/jetty.project/blob/jetty-9.4.43.v20210624/pom.xml#L163
* https://github.com/eclipse/jetty.project/blob/jetty-10.0.0/pom.xml#L166
