### PR TITLE
Update default webapp-runner to 9.0.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,10 +302,10 @@ This option can be used to enable SSL and HTTPS.
 ### Tomcat version
 
 By default, [Webapp Runner](https://github.com/heroku/webapp-runner)
-9.0.38.0 is used.  To use a different version, set `containerLibs`:
-
+9.0.41.0 is used.  To use a different version, set `containerLibs`:
+41
 ```scala
-containerLibs in Tomcat := Seq("com.github.jsimone" % "webapp-runner" % "7.0.34.1" intransitive())
+containerLibs in Tomcat := Seq("com.heroku" % "webapp-runner" % "8.5.61.0" intransitive())
 ```
 
 Depending on the version, it may also be necessary to specify the name

--- a/src/main/scala/com/earldouglas/xwp/TomcatPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/TomcatPlugin.scala
@@ -17,7 +17,7 @@ object TomcatPlugin extends AutoPlugin {
 
   override val projectConfigurations = Seq(Tomcat)
 
-  val webappRunner = "com.heroku" % "webapp-runner" % "9.0.38.0"
+  val webappRunner = "com.heroku" % "webapp-runner" % "9.0.41.0"
 
   override lazy val projectSettings =
     ContainerPlugin.containerSettings(Tomcat) ++

--- a/src/sbt-test/container/combined/test
+++ b/src/sbt-test/container/combined/test
@@ -16,6 +16,36 @@ $ copy-file sbt/tomcat.sbt tomcat.sbt
 > tomcat:stop
 -> get http://localhost:8080/test 200
 
+## tomcat 7
+
+> reload
+> 'set containerLibs in Tomcat := Seq("com.github.jsimone" % "webapp-runner" % "7.0.91.0" intransitive())'
+> tomcat:start
+> await 8080
+> get http://localhost:8080/test 200
+> tomcat:stop
+-> get http://localhost:8080/test 200
+
+## tomcat 8
+
+> reload
+> 'set containerLibs in Tomcat := Seq("com.github.jsimone" % "webapp-runner" % "8.0.52.0" intransitive())'
+> tomcat:start
+> await 8080
+> get http://localhost:8080/test 200
+> tomcat:stop
+-> get http://localhost:8080/test 200
+
+## tomcat 8.5
+
+> reload
+> 'set containerLibs in Tomcat := Seq("com.heroku" % "webapp-runner" % "8.5.61.0" intransitive())'
+> tomcat:start
+> await 8080
+> get http://localhost:8080/test 200
+> tomcat:stop
+-> get http://localhost:8080/test 200
+
 # jetty
 
 $ delete tomcat.sbt


### PR DESCRIPTION
This also adds tests for webapp-runner 7.0.91.0, 8.0.52.0, and 8.5.61.0.

See https://repo1.maven.org/maven2/com/heroku/webapp-runner/