### PR TITLE
Standardize formatting with Scalafmt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - run: sbt scalafmtCheckAll
     - run: sbt ^test
     - run: sbt ^publishLocal
     - run: sbt scripted

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,1 @@
+maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/src/main/scala-sbt-1.0/com/earldouglas/xwp/Compat.scala
+++ b/src/main/scala-sbt-1.0/com/earldouglas/xwp/Compat.scala
@@ -14,15 +14,30 @@ object Compat {
   def forkOptionsWithRunJVMOptions(options: Seq[String]) =
     ForkOptions().withRunJVMOptions(options.toVector)
 
-  val watchSourceSetting = watchSources += new Source((sourceDirectory in webappPrepare).value, AllPassFilter, NothingFilter)
+  val watchSourceSetting = watchSources += new Source(
+    (sourceDirectory in webappPrepare).value,
+    AllPassFilter,
+    NothingFilter
+  )
 
-  def cached(cacheBaseDirectory: File, inStyle: Style, outStyle: Style)(action: (ChangeReport[File], ChangeReport[File]) => Set[File]): Set[File] => Set[File] = 
-    sbt.util.FileFunction.cached(CacheStoreFactory(cacheBaseDirectory), inStyle = inStyle, outStyle = outStyle)(action = action)
+  def cached(cacheBaseDirectory: File, inStyle: Style, outStyle: Style)(
+      action: (ChangeReport[File], ChangeReport[File]) => Set[File]
+  ): Set[File] => Set[File] =
+    sbt.util.FileFunction.cached(
+      CacheStoreFactory(cacheBaseDirectory),
+      inStyle = inStyle,
+      outStyle = outStyle
+    )(action = action)
 
-  def jar(sources: Traversable[(File, String)], outputJar: File, manifest: java.util.jar.Manifest): Unit =
-    io.IO.jar( sources = sources
-             , outputJar = outputJar
-             , manifest = manifest
-             , time = None
-             )
+  def jar(
+      sources: Traversable[(File, String)],
+      outputJar: File,
+      manifest: java.util.jar.Manifest
+  ): Unit =
+    io.IO.jar(
+      sources = sources,
+      outputJar = outputJar,
+      manifest = manifest,
+      time = None
+    )
 }

--- a/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/ContainerPlugin.scala
@@ -10,32 +10,42 @@ import Compat.Process
 object ContainerPlugin extends AutoPlugin {
 
   lazy val quickstart = taskKey[Seq[Process]]("quickstart container")
-  lazy val start      = taskKey[Seq[Process]]("start container")
-  lazy val debug      = taskKey[Seq[Process]]("start container in debug mode")
-  lazy val join       = taskKey[Seq[Int]]("join container")
-  lazy val stop       = taskKey[Unit]("stop container")
-  lazy val quicktest  = taskKey[Unit]("test under quickstarted container")
-  lazy val test       = taskKey[Unit]("test under started container")
+  lazy val start = taskKey[Seq[Process]]("start container")
+  lazy val debug =
+    taskKey[Seq[Process]]("start container in debug mode")
+  lazy val join = taskKey[Seq[Int]]("join container")
+  lazy val stop = taskKey[Unit]("stop container")
+  lazy val quicktest =
+    taskKey[Unit]("test under quickstarted container")
+  lazy val test = taskKey[Unit]("test under started container")
 
   object autoImport {
     val Container = config("container").hide
 
-    val debugPort               = settingKey[Int]("port to be used for debugging")
-    val debugOptions            = settingKey[Int => Seq[String]]("debug options")
+    val debugPort = settingKey[Int]("port to be used for debugging")
+    val debugOptions = settingKey[Int => Seq[String]]("debug options")
 
-    val containerLibs           = settingKey[Seq[ModuleID]]("container libraries")
-    val containerMain           = settingKey[String]("container main class")
-    val containerPort           = settingKey[Int]("port number to be used by container")
-    val containerArgs           = settingKey[Seq[String]]("additional container args")
-    val containerForkOptions    = settingKey[ForkOptions]("fork options")
-    val containerShutdownOnExit = settingKey[Boolean]("shutdown container on sbt exit")
-    val containerScale          = settingKey[Int]("number of container instances to start")
+    val containerLibs = settingKey[Seq[ModuleID]]("container libraries")
+    val containerMain = settingKey[String]("container main class")
+    val containerPort =
+      settingKey[Int]("port number to be used by container")
+    val containerArgs =
+      settingKey[Seq[String]]("additional container args")
+    val containerForkOptions = settingKey[ForkOptions]("fork options")
+    val containerShutdownOnExit =
+      settingKey[Boolean]("shutdown container on sbt exit")
+    val containerScale =
+      settingKey[Int]("number of container instances to start")
 
-    val containerLaunchCmd      = taskKey[(Int, String) => Seq[String]]("command to launch container")
+    val containerLaunchCmd = taskKey[(Int, String) => Seq[String]](
+      "command to launch container"
+    )
   }
 
   private lazy val containerInstances =
-    settingKey[AtomicReference[Seq[Process]]]("current container process")
+    settingKey[AtomicReference[Seq[Process]]](
+      "current container process"
+    )
 
   import WebappPlugin.autoImport.webappPrepare
   import WebappPlugin.autoImport.webappPrepareQuick
@@ -47,46 +57,56 @@ object ContainerPlugin extends AutoPlugin {
 
   override lazy val projectSettings =
     containerSettings(Container) ++
-      inConfig(Container)(Seq(
-        containerLibs := Nil
-      , containerMain := ""
-      ))
+      inConfig(Container)(
+        Seq(
+          containerLibs := Nil,
+          containerMain := ""
+        )
+      )
 
   def containerSettings(conf: Configuration) =
     baseContainerSettings ++
-      Seq(libraryDependencies ++= (containerLibs in conf).value.map(_ % conf)) ++
-      inConfig(conf)(Seq(
-        start              := (startTask dependsOn webappPrepare).value
-      , quickstart         := (quickstartTask dependsOn webappPrepareQuick).value
-      , debug              := (debugTask dependsOn webappPrepare).value
-      , join               := joinTask.value
-      , stop               := stopTask.value
-      , quicktest          := ((test in Test) dependsOn awaitOpenTask dependsOn quickstart dependsOn (compile in Test)).value
-      , test               := ((test in Test) dependsOn awaitOpenTask dependsOn start dependsOn (compile in Test)).value
-      , onLoad in Global   := onLoadSetting.value
-      , javaOptions        := (javaOptions in Compile).value
-      , containerLaunchCmd := defaultLaunchCmd.value
-      ))
+      Seq(
+        libraryDependencies ++= (containerLibs in conf).value
+          .map(_ % conf)
+      ) ++
+      inConfig(conf)(
+        Seq(
+          start := (startTask dependsOn webappPrepare).value,
+          quickstart := (quickstartTask dependsOn webappPrepareQuick).value,
+          debug := (debugTask dependsOn webappPrepare).value,
+          join := joinTask.value,
+          stop := stopTask.value,
+          quicktest := ((test in Test) dependsOn awaitOpenTask dependsOn quickstart dependsOn (compile in Test)).value,
+          test := ((test in Test) dependsOn awaitOpenTask dependsOn start dependsOn (compile in Test)).value,
+          onLoad in Global := onLoadSetting.value,
+          javaOptions := (javaOptions in Compile).value,
+          containerLaunchCmd := defaultLaunchCmd.value
+        )
+      )
 
   def _debugOptions(port: Int): Seq[String] =
-    Seq( "-Xdebug"
-       , Seq( "-Xrunjdwp:transport=dt_socket"
-            , "address=" + port
-            , "server=y"
-            , "suspend=n"
-            ).mkString(",")
-       )
+    Seq(
+      "-Xdebug",
+      Seq(
+        "-Xrunjdwp:transport=dt_socket",
+        "address=" + port,
+        "server=y",
+        "suspend=n"
+      ).mkString(",")
+    )
 
   lazy val baseContainerSettings =
-    Seq( containerPort           := 8080
-       , containerArgs           := Nil
-       , containerForkOptions    := ForkOptions()
-       , containerInstances      := new AtomicReference(Seq.empty[Process])
-       , containerShutdownOnExit := true
-       , debugPort               := 8888
-       , debugOptions            := _debugOptions
-       , containerScale          := 1
-       )
+    Seq(
+      containerPort := 8080,
+      containerArgs := Nil,
+      containerForkOptions := ForkOptions(),
+      containerInstances := new AtomicReference(Seq.empty[Process]),
+      containerShutdownOnExit := true,
+      debugPort := 8888,
+      debugOptions := _debugOptions,
+      containerScale := 1
+    )
 
   private def defaultLaunchCmd =
     Def.task {
@@ -102,8 +122,8 @@ object ContainerPlugin extends AutoPlugin {
       }
     }
 
-  private def startTask      = launchTask(false, false)
-  private def debugTask      = launchTask(false, true)
+  private def startTask = launchTask(false, false)
+  private def debugTask = launchTask(false, true)
   private def quickstartTask = launchTask(true, false)
 
   private def launchTask(quick: Boolean, debug: Boolean) =
@@ -115,8 +135,12 @@ object ContainerPlugin extends AutoPlugin {
       shutdown(log, instances)
 
       val libs: Seq[File] =
-        (fullClasspath in Runtime).value.map(_.data).filter(_ => quick) ++
-        Classpaths.managedJars(conf, classpathTypes.value, update.value).map(_.data)
+        (fullClasspath in Runtime).value
+          .map(_.data)
+          .filter(_ => quick) ++
+          Classpaths
+            .managedJars(conf, classpathTypes.value, update.value)
+            .map(_.data)
 
       val path = {
         if (quick) {
@@ -129,22 +153,25 @@ object ContainerPlugin extends AutoPlugin {
       def launchFn(_containerPort: Int, _debugPort: Int): Process = {
         val args: Seq[String] =
           javaOptions.value ++
-          debugOptions.value(_debugPort).filter(_ => debug) ++
-          containerLaunchCmd.value(_containerPort, path)
+            debugOptions.value(_debugPort).filter(_ => debug) ++
+            containerLaunchCmd.value(_containerPort, path)
         startup(log, libs, args, containerForkOptions.value)
       }
 
       val startContainerPort: Int = containerPort.value
-      val endContainerPort: Int = containerPort.value + containerScale.value - 1
+      val endContainerPort: Int =
+        containerPort.value + containerScale.value - 1
 
       val startDebugPort: Int = debugPort.value
       val endDebugPort: Int = debugPort.value + containerScale.value - 1
 
-      val ports: Seq[(Int,Int)] =
+      val ports: Seq[(Int, Int)] =
         (startContainerPort to endContainerPort) zip
-        (startDebugPort to endDebugPort)
+          (startDebugPort to endDebugPort)
 
-      val processes: Seq[Process] = ports map { case (c, d) => launchFn(c, d) }
+      val processes: Seq[Process] = ports map {
+        case (c, d) => launchFn(c, d)
+      }
       instances.set(processes)
       processes
     }
@@ -156,17 +183,20 @@ object ContainerPlugin extends AutoPlugin {
     Def.task { shutdown(streams.value.log, containerInstances.value) }
 
   private def validateSbtVerison(version: String): Unit = {
-    val versionArray = version.split("\\.").map(_.split("-")).map(_(0).toInt)
+    val versionArray =
+      version.split("\\.").map(_.split("-")).map(_(0).toInt)
     val major = versionArray(0)
     val minor = versionArray(1)
     val patch = versionArray(2)
 
-    if ((major == 0 && minor < 13) ||
-        (major == 0 && minor == 13 && patch < 6)) {
+    if (
+      (major == 0 && minor < 13) ||
+      (major == 0 && minor == 13 && patch < 6)
+    ) {
       throw new RuntimeException(
-         "xsbt-web-plugin requires sbt 0.13.6+, " +
-         "but this project is configured to use sbt " +
-         version
+        "xsbt-web-plugin requires sbt 0.13.6+, " +
+          "but this project is configured to use sbt " +
+          version
       )
     }
   }
@@ -176,18 +206,21 @@ object ContainerPlugin extends AutoPlugin {
       (onLoad in Global).value compose { state: State =>
         validateSbtVerison(state.configuration.provider.id.version)
         if ((containerShutdownOnExit).value) {
-          state.addExitHook(shutdown(state.log, containerInstances.value))
+          state.addExitHook(
+            shutdown(state.log, containerInstances.value)
+          )
         } else {
           state
         }
       }
     }
 
-  private def startup( l: Logger
-                     , libs: Seq[File]
-                     , args: Seq[String]
-                     , forkOptions: ForkOptions
-                     ): Process = {
+  private def startup(
+      l: Logger,
+      libs: Seq[File],
+      args: Seq[String],
+      forkOptions: ForkOptions
+  ): Process = {
     l.info("starting server ...")
     val cp = Path.makeString(libs)
     new Fork("java", None).fork(forkOptions, Seq("-cp", cp) ++ args)
@@ -208,9 +241,10 @@ object ContainerPlugin extends AutoPlugin {
     System.setErr(err)
   }
 
-  private def shutdown( l: Logger
-                      , atomicRef: AtomicReference[Seq[Process]]
-                      ): Unit = {
+  private def shutdown(
+      l: Logger,
+      atomicRef: AtomicReference[Seq[Process]]
+  ): Unit = {
     val oldProcess = atomicRef.getAndSet(Seq.empty[Process])
     oldProcess.foreach(stopProcess(l))
   }
@@ -233,7 +267,9 @@ object ContainerPlugin extends AutoPlugin {
           Thread.sleep(250)
           awaitOpen(port, retries - 1)
         } else {
-          throw new Exception(s"gave up waiting for port $port to be open")
+          throw new Exception(
+            s"gave up waiting for port $port to be open"
+          )
         }
       }
     }

--- a/src/main/scala/com/earldouglas/xwp/ElasticBeanstalkDeploy.scala
+++ b/src/main/scala/com/earldouglas/xwp/ElasticBeanstalkDeploy.scala
@@ -24,45 +24,54 @@ import sbt.Keys.{`package` => pkg}
 object ElasticBeanstalkDeployPlugin extends AutoPlugin {
 
   object autoImport {
-    lazy val elasticBeanstalkDeploy  = taskKey[Unit]("Deploy .war file to Elastic Beanstalk")
-    lazy val elasticBeanstalkRegion  = settingKey[String]("Elastic Beanstalk region, e.g. us-west-1")
-    lazy val elasticBeanstalkAppName = settingKey[String]("Elastic Beanstalk application name, e.g. my-app")
-    lazy val elasticBeanstalkEnvName = settingKey[String]("Elastic Beanstalk environment name, e.g. my-env")
+    lazy val elasticBeanstalkDeploy =
+      taskKey[Unit]("Deploy .war file to Elastic Beanstalk")
+    lazy val elasticBeanstalkRegion =
+      settingKey[String]("Elastic Beanstalk region, e.g. us-west-1")
+    lazy val elasticBeanstalkAppName = settingKey[String](
+      "Elastic Beanstalk application name, e.g. my-app"
+    )
+    lazy val elasticBeanstalkEnvName = settingKey[String](
+      "Elastic Beanstalk environment name, e.g. my-env"
+    )
   }
 
   import autoImport._
 
   override def projectSettings =
-    Seq(elasticBeanstalkDeploy := deploy( (packagedArtifact in (Compile, pkg), pkg)._2.value
-                                         , elasticBeanstalkRegion.value
-                                         , elasticBeanstalkAppName.value
-                                         , elasticBeanstalkEnvName.value
-                                         , version.value
-                                         )
-  )
+    Seq(
+      elasticBeanstalkDeploy := deploy(
+        (packagedArtifact in (Compile, pkg), pkg)._2.value,
+        elasticBeanstalkRegion.value,
+        elasticBeanstalkAppName.value,
+        elasticBeanstalkEnvName.value,
+        version.value
+      )
+    )
 
-  def deploy( warFile: File
-            , region: String
-            , appName: String
-            , envName: String
-            , version: String
-            ): Unit = {
+  def deploy(
+      warFile: File,
+      region: String,
+      appName: String,
+      envName: String,
+      version: String
+  ): Unit = {
 
     val creds = new EnvironmentVariableCredentialsProvider
 
     val eb: AWSElasticBeanstalk =
-      AWSElasticBeanstalkClientBuilder.
-          standard().
-          withRegion(region).
-          withCredentials(creds).
-          build()
+      AWSElasticBeanstalkClientBuilder
+        .standard()
+        .withRegion(region)
+        .withCredentials(creds)
+        .build()
 
     val s3: AmazonS3 =
-      AmazonS3ClientBuilder.
-          standard().
-          withRegion(region).
-          withCredentials(creds).
-          build()
+      AmazonS3ClientBuilder
+        .standard()
+        .withRegion(region)
+        .withCredentials(creds)
+        .build()
 
     val s3Location = uploadWarFile(eb, s3, warFile)
     deleteApplicationVersion(eb, appName, version)
@@ -71,49 +80,58 @@ object ElasticBeanstalkDeployPlugin extends AutoPlugin {
 
   }
 
-  def uploadWarFile( eb: AWSElasticBeanstalk
-                   , s3: AmazonS3
-                   , warFile: File
-                   ): S3Location = {
+  def uploadWarFile(
+      eb: AWSElasticBeanstalk,
+      s3: AmazonS3,
+      warFile: File
+  ): S3Location = {
     val bucketName = eb.createStorageLocation().getS3Bucket()
     val key = URLEncoder.encode(warFile.getName(), "UTF-8")
     val s3Result = s3.putObject(bucketName, key, warFile)
     new S3Location(bucketName, key)
   }
 
-  def deleteApplicationVersion( eb: AWSElasticBeanstalk
-                              , appName: String
-                              , version: String
-                              ): Unit = {
-    val describeApplicationVersionsRequest = new DescribeApplicationVersionsRequest()
+  def deleteApplicationVersion(
+      eb: AWSElasticBeanstalk,
+      appName: String,
+      version: String
+  ): Unit = {
+    val describeApplicationVersionsRequest =
+      new DescribeApplicationVersionsRequest()
     describeApplicationVersionsRequest.setApplicationName(appName)
-    describeApplicationVersionsRequest.setVersionLabels(Arrays.asList(version))
+    describeApplicationVersionsRequest.setVersionLabels(
+      Arrays.asList(version)
+    )
 
-    val result = eb.describeApplicationVersions(describeApplicationVersionsRequest)
+    val result =
+      eb.describeApplicationVersions(describeApplicationVersionsRequest)
     if (!result.getApplicationVersions().isEmpty()) {
-      val deleteRequest = new DeleteApplicationVersionRequest(appName, version)
+      val deleteRequest =
+        new DeleteApplicationVersionRequest(appName, version)
       deleteRequest.setDeleteSourceBundle(true)
       eb.deleteApplicationVersion(deleteRequest)
     }
   }
 
-  def createApplicationVersion( eb: AWSElasticBeanstalk                  
-                              , appName: String
-                              , version: String
-                              , s3Location: S3Location
-                              ): Unit = {
+  def createApplicationVersion(
+      eb: AWSElasticBeanstalk,
+      appName: String,
+      version: String,
+      s3Location: S3Location
+  ): Unit = {
     val createApplicationVersionRequest =
-      new CreateApplicationVersionRequest(appName , version)
+      new CreateApplicationVersionRequest(appName, version)
     createApplicationVersionRequest.setAutoCreateApplication(true)
     createApplicationVersionRequest.setSourceBundle(s3Location)
 
     eb.createApplicationVersion(createApplicationVersionRequest)
   }
 
-  def updateEnvironment( eb: AWSElasticBeanstalk                  
-                       , envName: String
-                       , version: String
-                       ): Unit = {
+  def updateEnvironment(
+      eb: AWSElasticBeanstalk,
+      envName: String,
+      version: String
+  ): Unit = {
     val updateEnviromentRequest = new UpdateEnvironmentRequest()
     updateEnviromentRequest.setEnvironmentName(envName)
     updateEnviromentRequest.setVersionLabel(version)

--- a/src/main/scala/com/earldouglas/xwp/HerokuDeploy.scala
+++ b/src/main/scala/com/earldouglas/xwp/HerokuDeploy.scala
@@ -11,24 +11,30 @@ object HerokuDeploy extends AutoPlugin {
   lazy val Deploy = config("deploy").hide
 
   object autoImport {
-    lazy val herokuOptions    = settingKey[Seq[String]]("Extra options for heroku-deploy")
-    lazy val herokuAppName    = settingKey[String]("Heroku App name")
-    lazy val herokuWarFile    = taskKey[File](".war file to deploy to Heroku")
-    lazy val herokuDeploy     = taskKey[Unit]("Deploy .war file to Heroku")
-    lazy val herokuDeployLib  = settingKey[ModuleID]("heroku-deploy library")
-    lazy val herokuDeployMain = settingKey[String]("heroku-deploy main class")
+    lazy val herokuOptions =
+      settingKey[Seq[String]]("Extra options for heroku-deploy")
+    lazy val herokuAppName = settingKey[String]("Heroku App name")
+    lazy val herokuWarFile =
+      taskKey[File](".war file to deploy to Heroku")
+    lazy val herokuDeploy = taskKey[Unit]("Deploy .war file to Heroku")
+    lazy val herokuDeployLib =
+      settingKey[ModuleID]("heroku-deploy library")
+    lazy val herokuDeployMain =
+      settingKey[String]("heroku-deploy main class")
   }
 
   import autoImport._
 
   override val projectConfigurations = Seq(Deploy)
 
-  def deploy(herokuOptions: Seq[String],
-             herokuAppName: String,
-             herokuWarFile: java.io.File,
-             classpathTypes: Set[String],
-             update: UpdateReport,
-             herokuDeployMain: String): Unit = {
+  def deploy(
+      herokuOptions: Seq[String],
+      herokuAppName: String,
+      herokuWarFile: java.io.File,
+      classpathTypes: Set[String],
+      update: UpdateReport,
+      herokuDeployMain: String
+  ): Unit = {
     val options = Compat.forkOptionsWithRunJVMOptions(
       herokuOptions.toVector ++ Seq(
         "-Dheroku.appName=" + herokuAppName,
@@ -38,23 +44,30 @@ object HerokuDeploy extends AutoPlugin {
     val libs: Seq[File] =
       Classpaths.managedJars(Deploy, classpathTypes, update).map(_.data)
 
-    val cp: String = libs map (_.getPath) mkString java.io.File.pathSeparator
+    val cp: String =
+      libs map (_.getPath) mkString java.io.File.pathSeparator
 
     Fork.java(options, Seq("-cp", cp, herokuDeployMain))
   }
 
-  override def projectSettings = Seq(
-    herokuOptions       := Seq("-Xmx1g"),
-    herokuWarFile       := (packagedArtifact in (Compile, pkg), pkg)._2.value,
-    herokuDeployLib     := "com.heroku.sdk" % "heroku-deploy" % "2.0.16",
-    herokuDeployMain    := "com.heroku.sdk.deploy.DeployWar",
-    libraryDependencies += herokuDeployLib.value % Deploy,
-    herokuDeploy        := deploy(herokuOptions.value,
-                                  herokuAppName.value,
-                                  herokuWarFile.value,
-                                  (classpathTypes in Deploy).value,
-                                  (update in Deploy).value,
-                                  herokuDeployMain.value)
-  )
+  override def projectSettings =
+    Seq(
+      herokuOptions := Seq("-Xmx1g"),
+      herokuWarFile := (
+        packagedArtifact in (Compile, pkg),
+        pkg
+      )._2.value,
+      herokuDeployLib := "com.heroku.sdk" % "heroku-deploy" % "2.0.16",
+      herokuDeployMain := "com.heroku.sdk.deploy.DeployWar",
+      libraryDependencies += herokuDeployLib.value % Deploy,
+      herokuDeploy := deploy(
+        herokuOptions.value,
+        herokuAppName.value,
+        herokuWarFile.value,
+        (classpathTypes in Deploy).value,
+        (update in Deploy).value,
+        herokuDeployMain.value
+      )
+    )
 
-} 
+}

--- a/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
@@ -17,13 +17,15 @@ object JettyPlugin extends AutoPlugin {
 
   override val projectConfigurations = Seq(Jetty)
 
-  val jettyRunner = "org.eclipse.jetty" % "jetty-runner" % "9.4.34.v20201102"
+  val jettyRunner =
+    "org.eclipse.jetty" % "jetty-runner" % "9.4.34.v20201102"
 
   override lazy val projectSettings =
     ContainerPlugin.containerSettings(Jetty) ++
       inConfig(Jetty)(
-        Seq( containerLibs := Seq(jettyRunner.intransitive())
-           , containerMain := "org.eclipse.jetty.runner.Runner"
-           )
+        Seq(
+          containerLibs := Seq(jettyRunner.intransitive()),
+          containerMain := "org.eclipse.jetty.runner.Runner"
+        )
       )
 }

--- a/src/main/scala/com/earldouglas/xwp/TomcatPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/TomcatPlugin.scala
@@ -22,8 +22,9 @@ object TomcatPlugin extends AutoPlugin {
   override lazy val projectSettings =
     ContainerPlugin.containerSettings(Tomcat) ++
       inConfig(Tomcat)(
-        Seq( containerLibs := Seq(webappRunner.intransitive())
-           , containerMain := "webapp.runner.launch.Main"
-           )
+        Seq(
+          containerLibs := Seq(webappRunner.intransitive()),
+          containerMain := "webapp.runner.launch.Main"
+        )
       )
 }

--- a/src/main/scala/com/earldouglas/xwp/WarPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WarPlugin.scala
@@ -11,29 +11,37 @@ object WarPlugin extends AutoPlugin {
   override def requires = WebappPlugin
 
   object autoImport {
-    val inheritJarManifest = settingKey[Boolean]("inherit .jar manifest")
+    val inheritJarManifest =
+      settingKey[Boolean]("inherit .jar manifest")
   }
 
   import autoImport._
 
-  private def manifestOptions = Def.task {
-    val opt = (packageOptions in (Compile, packageBin)).value
-    if (inheritJarManifest.value) {
-      opt.filter {
-        case x: Package.ManifestAttributes => true
-        case _ => false
+  private def manifestOptions =
+    Def.task {
+      val opt = (packageOptions in (Compile, packageBin)).value
+      if (inheritJarManifest.value) {
+        opt.filter {
+          case x: Package.ManifestAttributes => true
+          case _                             => false
+        }
+      } else {
+        Seq.empty
       }
-    } else {
-      Seq.empty
     }
-  }
 
   override lazy val projectSettings =
-    Defaults.packageTaskSettings(pkg, WebappPlugin.autoImport.webappPrepare) ++
-    Seq(artifact in pkg := Artifact(moduleName.value, "war", "war")) ++
-    addArtifact(artifact in (Compile, pkg), pkg) ++
-    Seq( inheritJarManifest := false
-       , packageOptions in sbt.Keys.`package` ++= manifestOptions.value
-       )
+    Defaults.packageTaskSettings(
+      pkg,
+      WebappPlugin.autoImport.webappPrepare
+    ) ++
+      Seq(
+        artifact in pkg := Artifact(moduleName.value, "war", "war")
+      ) ++
+      addArtifact(artifact in (Compile, pkg), pkg) ++
+      Seq(
+        inheritJarManifest := false,
+        packageOptions in sbt.Keys.`package` ++= manifestOptions.value
+      )
 
 }

--- a/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/WebappPlugin.scala
@@ -13,10 +13,17 @@ import sbt.FileFunction.cached
 object WebappPlugin extends AutoPlugin {
 
   object autoImport {
-    lazy val webappPrepare       = taskKey[Seq[(File, String)]]("prepare webapp contents for packaging")
-    lazy val webappPrepareQuick  = taskKey[Seq[(File, String)]]("prepare webapp contents for quickstart")
-    lazy val webappPostProcess   = taskKey[File => Unit]("additional task after preparing the webapp")
-    lazy val webappWebInfClasses = settingKey[Boolean]("use WEB-INF/classes instead of WEB-INF/lib")
+    lazy val webappPrepare = taskKey[Seq[(File, String)]](
+      "prepare webapp contents for packaging"
+    )
+    lazy val webappPrepareQuick = taskKey[Seq[(File, String)]](
+      "prepare webapp contents for quickstart"
+    )
+    lazy val webappPostProcess = taskKey[File => Unit](
+      "additional task after preparing the webapp"
+    )
+    lazy val webappWebInfClasses =
+      settingKey[Boolean]("use WEB-INF/classes instead of WEB-INF/lib")
   }
 
   import autoImport._
@@ -25,76 +32,83 @@ object WebappPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] =
     Seq(
-        sourceDirectory in webappPrepare := (sourceDirectory in Compile).value / "webapp"
-      , target in webappPrepare          := (target in Compile).value / "webapp"
-      , target in webappPrepareQuick     := (target in Compile).value / "webapp-quick"
-      , webappPrepare                    := webappPrepareTask.value
-      , webappPrepareQuick               := webappPrepareQuickTask.value
-      , webappPostProcess                := { _ => () }
-      , webappWebInfClasses              := false
-      , Compat.watchSourceSetting
+      sourceDirectory in webappPrepare := (sourceDirectory in Compile).value / "webapp",
+      target in webappPrepare := (target in Compile).value / "webapp",
+      target in webappPrepareQuick := (target in Compile).value / "webapp-quick",
+      webappPrepare := webappPrepareTask.value,
+      webappPrepareQuick := webappPrepareQuickTask.value,
+      webappPostProcess := { _ => () },
+      webappWebInfClasses := false,
+      Compat.watchSourceSetting
     )
 
-  private def cacheify( name: String
-                      , dest: File => Option[File]
-                      , in: Set[File]
-                      , streams: TaskStreams
-                      ): Set[File] =
-    Compat.cached(streams.cacheDirectory / "xsbt-web-plugin" / name, lastModified, exists)({
-      (inChanges, outChanges) =>
-
+  private def cacheify(
+      name: String,
+      dest: File => Option[File],
+      in: Set[File],
+      streams: TaskStreams
+  ): Set[File] =
+    Compat
+      .cached(
+        streams.cacheDirectory / "xsbt-web-plugin" / name,
+        lastModified,
+        exists
+      )({ (inChanges, outChanges) =>
         // toss out removed files
         for {
-          removed  <- inChanges.removed
+          removed <- inChanges.removed
           toRemove <- dest(removed)
         } yield IO.delete(toRemove)
 
         // new files
         val newFiles =
           for {
-            in  <- inChanges.added -- inChanges.removed
+            in <- inChanges.added -- inChanges.removed
             out <- dest(in)
-            _    = IO.copyFile(in, out)
+            _ = IO.copyFile(in, out)
           } yield out
 
         // modified files
         val modifiedFiles =
           for {
-            in  <- inChanges.modified -- inChanges.removed
+            in <- inChanges.modified -- inChanges.removed
             out <- dest(in)
-            _    = IO.copyFile(in, out)
+            _ = IO.copyFile(in, out)
           } yield out
 
         // missing files
         val missingFiles =
           for {
-            in  <- inChanges.checked -- inChanges.removed
+            in <- inChanges.checked -- inChanges.removed
             out <- dest(in).toSet & outChanges.modified
-            _    = IO.copyFile(in, out)
+            _ = IO.copyFile(in, out)
           } yield out
 
         // all files
         newFiles ++ modifiedFiles ++ missingFiles
-    }).apply(in)
+      })
+      .apply(in)
 
-  private def _webappPrepare( webappTarget: SettingKey[File]
-                            , cacheName: String
-                            ) =
+  private def _webappPrepare(
+      webappTarget: SettingKey[File],
+      cacheName: String
+  ) =
     Def.task {
 
       val webappSrcDir = (sourceDirectory in webappPrepare).value
 
-      cacheify( cacheName
-              , { in =>
-                  for {
-                    f <- Some(in)
-                    if !f.isDirectory
-                    r <- IO.relativizeFile(webappSrcDir, f)
-                  } yield IO.resolve(webappTarget.value, r)
-                }
-              , (webappSrcDir ** "*").get.toSet
-              , streams.value
-              )
+      cacheify(
+        cacheName,
+        { in =>
+          for {
+            f <- Some(in)
+            if !f.isDirectory
+            r <- IO.relativizeFile(webappSrcDir, f)
+          } yield IO.resolve(webappTarget.value, r)
+        },
+        (webappSrcDir ** "*").get.toSet,
+        streams.value
+      )
 
       webappTarget.value
     }
@@ -103,13 +117,16 @@ object WebappPlugin extends AutoPlugin {
     Def.task {
 
       val webappTarget =
-        _webappPrepare( target in webappPrepareQuick
-                      , "webapp-quick"
-                      ).value
+        _webappPrepare(
+          target in webappPrepareQuick,
+          "webapp-quick"
+        ).value
 
       webappPostProcess.value(webappTarget)
 
-      (webappTarget ** "*") pair (Path.relativeTo(webappTarget) | Path.flat)
+      (webappTarget ** "*") pair (Path.relativeTo(
+        webappTarget
+      ) | Path.flat)
     }
 
   private def webappPrepareTask =
@@ -118,9 +135,7 @@ object WebappPlugin extends AutoPlugin {
       val taskStreams = streams.value
 
       val webappTarget =
-        _webappPrepare( target in webappPrepare
-                      , "webapp"
-                      ).value
+        _webappPrepare(target in webappPrepare, "webapp").value
 
       val m = (mappings in (Compile, packageBin)).value
       val p = (packagedArtifact in (Compile, packageBin)).value._2
@@ -130,66 +145,76 @@ object WebappPlugin extends AutoPlugin {
 
       if (webappWebInfClasses.value) {
         // copy this project's classes directly to WEB-INF/classes
-        cacheify( "classes"
-                , { in =>
-                    m find {
-                      case (src, dest) => src == in
-                    } map { case (src, dest) =>
-                      webInfDir / "classes" / dest
-                    }
-                  }
-                , (m filter {
-                    case (src, dest) => !src.isDirectory
-                  } map { case (src, dest) =>
-                    src
-                  }).toSet
-                , taskStreams
-                )
+        cacheify(
+          "classes",
+          { in =>
+            m find {
+              case (src, dest) => src == in
+            } map {
+              case (src, dest) =>
+                webInfDir / "classes" / dest
+            }
+          },
+          (m filter {
+            case (src, dest) => !src.isDirectory
+          } map {
+            case (src, dest) =>
+              src
+          }).toSet,
+          taskStreams
+        )
       } else {
         // copy this project's classes as a .jar file in WEB-INF/lib
-        cacheify( "lib-art"
-                , { in => Some(webappLibDir / in.getName) }
-                , Set(p)
-                , taskStreams
-                )
+        cacheify(
+          "lib-art",
+          { in => Some(webappLibDir / in.getName) },
+          Set(p),
+          taskStreams
+        )
       }
 
       val classpath = (fullClasspath in Runtime).value
 
       // create .jar files for depended-on projects in WEB-INF/lib
       for {
-        cpItem    <- classpath.toList
-        dir        = cpItem.data
+        cpItem <- classpath.toList
+        dir = cpItem.data
         if dir.isDirectory
-        artEntry  <- cpItem.metadata.entries find { e => e.key.label == "artifact" }
-        cpArt      = artEntry.value.asInstanceOf[Artifact]
-        artifact   = (packagedArtifact in (Compile, packageBin)).value._1
-        if cpArt  != artifact
-        files      = (dir ** "*").get flatMap { file =>
+        artEntry <- cpItem.metadata.entries find { e =>
+          e.key.label == "artifact"
+        }
+        cpArt = artEntry.value.asInstanceOf[Artifact]
+        artifact = (packagedArtifact in (Compile, packageBin)).value._1
+        if cpArt != artifact
+        files = (dir ** "*").get flatMap { file =>
           if (!file.isDirectory)
             IO.relativize(dir, file) map { p => (file, p) }
           else
             None
         }
-        jarFile    = cpArt.name + ".jar"
-        _          = Compat.jar( sources = files
-                               , outputJar = webappLibDir / jarFile
-                               , manifest = new Manifest
-                               )
+        jarFile = cpArt.name + ".jar"
+        _ = Compat.jar(
+          sources = files,
+          outputJar = webappLibDir / jarFile,
+          manifest = new Manifest
+        )
       } yield ()
 
       // copy this project's library dependency .jar files to WEB-INF/lib
-      cacheify( "lib-deps"
-              , { in => Some(webappTarget / "WEB-INF" / "lib" / in.getName) }
-              , classpath.map(_.data).toSet filter { in =>
-                  !in.isDirectory && in.getName.endsWith(".jar")
-                }
-              , taskStreams
-              )
+      cacheify(
+        "lib-deps",
+        { in => Some(webappTarget / "WEB-INF" / "lib" / in.getName) },
+        classpath.map(_.data).toSet filter { in =>
+          !in.isDirectory && in.getName.endsWith(".jar")
+        },
+        taskStreams
+      )
 
       webappPostProcess.value(webappTarget)
 
-      (webappTarget ** "*") pair (Path.relativeTo(webappTarget) | Path.flat)
+      (webappTarget ** "*") pair (Path.relativeTo(
+        webappTarget
+      ) | Path.flat)
     }
 
 }


### PR DESCRIPTION
This adds Scalafmt, applies it to the source code, and adds a build-time
check in CI.  Scalafmt doesn't technically support Scala 2.12.11:

```
[info] Checking 8 Scala sources...
[error] Invalid version: 2.12.11: xsbt-web-plugin/.scalafmt.conf
[error] Invalid version: 2.12.11: xsbt-web-plugin/.scalafmt.conf
[error] (Compile / scalafmtCheck) Invalid version: 2.12.11: xsbt-web-plugin/.scalafmt.conf
[error] (Test / scalafmtCheck) Invalid version: 2.12.11: xsbt-web-plugin/.scalafmt.conf
```

But it doesn't complain if we don't tell it what version we're on.

See https://scalameta.org/scalafmt/docs/installation.html#sbt
