### PR TITLE
Don't use Bintray to retrieve sbt-launch.jar

### DIFF
--- a/src/reqs/check.sh
+++ b/src/reqs/check.sh
@@ -38,7 +38,7 @@ function _test() {
 # sbt 0.13
 for SBT_VERSION in 0.13.6 0.13.18
 do
-  SBT_LAUNCH=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar
+  SBT_LAUNCH=https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar
   test
 done
 


### PR DESCRIPTION
With Bintray [shutting down][1], the servers simply return `Forbidden!`
when trying to retrieve *sbt-launch.jar*.  This switches to Typesafe's
repo instead.

[1]: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/