### PR TITLE
Throw an error on non-zero exit from HerokuDeploy

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/HerokuDeploy.scala
+++ b/src/main/scala/com/earldouglas/xwp/HerokuDeploy.scala
@@ -47,7 +47,12 @@ object HerokuDeploy extends AutoPlugin {
     val cp: String =
       libs map (_.getPath) mkString java.io.File.pathSeparator
 
-    Fork.java(options, Seq("-cp", cp, herokuDeployMain))
+    val exitCode: Int =
+      Fork.java(options, Seq("-cp", cp, herokuDeployMain))
+
+    if (exitCode != 0) {
+      sys.error("Couldn't deploy to Heroku")
+    }
   }
 
   override def projectSettings =


### PR DESCRIPTION
This causes sbt to return an error status when `herokuDeploy` fails, as
detected by a non-zero exit code from the forked process.  This helps
flag CI if something goes wrong during deployment.

Fixes #465