### PR TITLE
Add crossSbtVersions to excludeLintKeys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 // General
 crossSbtVersions := Seq("0.13.18", "1.5.4")
+Global / excludeLintKeys += crossSbtVersions // don't warn about unused setting
 enablePlugins(SbtPlugin)
 name := "xsbt-web-plugin"
 organization := "com.earldouglas"


### PR DESCRIPTION
This prevents sbt from complaining about the `crossSbtVersions` key
not being used by any other settings/tasks:

```
[warn] there's a key that's not used by any other settings/tasks:
[warn]
[warn] * xsbt-web-plugin / crossSbtVersions
[warn]   +- build.sbt:2
[warn]
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```