### PR TITLE
Update sbt-scalafmt to 2.4.4

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,3 @@
+version=3.1.1
+runner.dialect=scala212
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.4")


### PR DESCRIPTION
Also add `version` and `runner.dialect`, which are now required, to the
Scalafmt config.