### PR TITLE
scalafmt-core: 3.7.7 -> 3.7.9

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.7.7 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+version = 3.7.9 // https://scalameta.org/scalafmt/docs/installation.html#sbt
 runner.dialect = scala212 // https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678


### PR DESCRIPTION
📦 Updates [org.scalameta:scalafmt-core](https://github.com/scalameta/scalafmt) from `3.7.7` to `3.7.9`

📜 [GitHub Release Notes](https://github.com/scalameta/scalafmt/releases/tag/v3.7.9) - [Version Diff](https://github.com/scalameta/scalafmt/compare/v3.7.7...v3.7.9)