### PR TITLE
sbt-scalafmt: 2.5.0 -> 2.5.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates [org.scalameta:sbt-scalafmt](https://github.com/scalameta/sbt-scalafmt) from `2.5.0` to `2.5.2`

📜 [GitHub Release Notes](https://github.com/scalameta/sbt-scalafmt/releases/tag/v2.5.2) - [Version Diff](https://github.com/scalameta/sbt-scalafmt/compare/v2.5.0...v2.5.2)