### PR TITLE
scalajs-dom: 2.6.0 -> 2.7.0

### DIFF
--- a/examples/scala-js/scala-js.sbt
+++ b/examples/scala-js/scala-js.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSPlugin)
 
-libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.6.0"
+libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.7.0"
 
 // Send generated JS to the XWP webapp dir
 crossTarget in fastOptJS := (target in webappPrepare).value


### PR DESCRIPTION
📦 Updates [org.scala-js:scalajs-dom](https://github.com/scala-js/scala-js-dom) from `2.6.0` to `2.7.0`

📜 [GitHub Release Notes](https://github.com/scala-js/scala-js-dom/releases/tag/v2.7.0) - [Version Diff](https://github.com/scala-js/scala-js-dom/compare/v2.6.0...v2.7.0)