### PR TITLE
sbt-scalajs: 1.13.2 -> 1.14.0

### DIFF
--- a/examples/scala-js/project/plugins.sbt
+++ b/examples/scala-js/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")


### PR DESCRIPTION
📦 Updates 
* [org.scala-js:sbt-scalajs](https://github.com/scala-js/scala-js)
* [org.scala-js:scalajs-compiler](https://github.com/scala-js/scala-js)
* [org.scala-js:scalajs-library](https://github.com/scala-js/scala-js)
* [org.scala-js:scalajs-test-bridge](https://github.com/scala-js/scala-js)

 from `1.13.2` to `1.14.0`

📜 [GitHub Release Notes](https://github.com/scala-js/scala-js/releases/tag/v1.14.0) - [Version Diff](https://github.com/scala-js/scala-js/compare/v1.13.2...v1.14.0)