### PR TITLE
compiler, scala-extensions-2.12: 0.9.10 -> 0.9.11

### DIFF
--- a/examples/mustache/build.sbt
+++ b/examples/mustache/build.sbt
@@ -1,5 +1,5 @@
-libraryDependencies += "com.github.spullara.mustache.java" % "scala-extensions-2.12" % "0.9.10"
-libraryDependencies += "com.github.spullara.mustache.java" % "compiler" % "0.9.10"
+libraryDependencies += "com.github.spullara.mustache.java" % "scala-extensions-2.12" % "0.9.11"
+libraryDependencies += "com.github.spullara.mustache.java" % "compiler" % "0.9.11"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.9" % "test"
 


### PR DESCRIPTION
📦 Updates 
* com.github.spullara.mustache.java:compiler
* com.github.spullara.mustache.java:scala-extensions-2.12

 from `0.9.10` to `0.9.11`