### PR TITLE
zio: 2.0.18 -> 2.0.19

### DIFF
--- a/examples/zio/build.sbt
+++ b/examples/zio/build.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "dev.zio" %% "zio" % "2.0.18"
+libraryDependencies += "dev.zio" %% "zio" % "2.0.19"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
 libraryDependencies += "com.h2database" % "h2" % "2.2.224"
 libraryDependencies += "com.jolbox" % "bonecp" % "0.8.0.RELEASE"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.18` to `2.0.19`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.0.19) - [Version Diff](https://github.com/zio/zio/compare/v2.0.18...v2.0.19)