### PR TITLE
aws-java-sdk: 1.12.641 -> 1.12.646

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scriptedBufferLog := false
 watchSources ++= { (sourceDirectory.value ** "*").get }
 
 // AWS deployment support
-val awsJavaSdkVersion = "1.12.641"
+val awsJavaSdkVersion = "1.12.646"
 libraryDependencies += "com.amazonaws" % "aws-java-sdk-elasticbeanstalk" % awsJavaSdkVersion
 libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % awsJavaSdkVersion
 


### PR DESCRIPTION
📦 Updates 
* com.amazonaws:aws-java-sdk-elasticbeanstalk
* com.amazonaws:aws-java-sdk-s3

 from `1.12.641` to `1.12.646`