### PR TITLE
scalatest: 3.2.17 -> 3.2.18

### DIFF
--- a/examples/async/build.sbt
+++ b/examples/async/build.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 enablePlugins(JettyPlugin)

--- a/examples/getting-started/build.sbt
+++ b/examples/getting-started/build.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 enablePlugins(JettyPlugin)

--- a/examples/http4s/build.sbt
+++ b/examples/http4s/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / scalaVersion := "3.2.2"
 libraryDependencies += "org.http4s" %% "http4s-dsl" % http4sVersion
 libraryDependencies += "org.http4s" %% "http4s-servlet" % http4sVersion
 libraryDependencies += "jakarta.servlet" % "jakarta.servlet-api" % "6.0.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 Jetty / containerLibs := Seq(
   "org.eclipse.jetty" % "jetty-runner" % "11.0.15" intransitive ()

--- a/examples/jetty-11/build.sbt
+++ b/examples/jetty-11/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies += "jakarta.servlet" % "jakarta.servlet-api" % "5.0.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 enablePlugins(JettyPlugin)
 

--- a/examples/scalatra/build.sbt
+++ b/examples/scalatra/build.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.scalatra" %% "scalatra" % "2.8.4"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 enablePlugins(JettyPlugin)
 

--- a/src/sbt-test/jetty-plugin/default/build.sbt
+++ b/src/sbt-test/jetty-plugin/default/build.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 enablePlugins(JettyPlugin)

--- a/src/sbt-test/scala/2/build.sbt
+++ b/src/sbt-test/scala/2/build.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 enablePlugins(JettyPlugin)

--- a/src/sbt-test/tomcat-plugin/default/build.sbt
+++ b/src/sbt-test/tomcat-plugin/default/build.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 enablePlugins(TomcatPlugin)


### PR DESCRIPTION
📦 Updates [org.scalatest:scalatest](https://github.com/scalatest/scalatest) from `3.2.17` to `3.2.18`

📜 [GitHub Release Notes](https://github.com/scalatest/scalatest/releases/tag/release-3.2.18) - [Version Diff](https://github.com/scalatest/scalatest/compare/release-3.2.17...release-3.2.18)