### PR TITLE
scala-library: 2.13.12 -> 2.13.13

### DIFF
--- a/examples/free/build.sbt
+++ b/examples/free/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12" // needed for fancy type inference
+scalaVersion := "2.13.13" // needed for fancy type inference
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding",


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.13.12` to `2.13.13`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.13.13) - [Version Diff](https://github.com/scala/scala/compare/v2.13.12...v2.13.13)