### PR TITLE
zio: 2.0.22 -> 2.1.2

### DIFF
--- a/.github/workflows/examples-zio.yml
+++ b/.github/workflows/examples-zio.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - run: |
         cd examples/zio
         sbt Jetty/test

--- a/examples/zio/build.sbt
+++ b/examples/zio/build.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "dev.zio" %% "zio" % "2.0.22"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.2"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
 libraryDependencies += "com.h2database" % "h2" % "2.2.224"
 libraryDependencies += "com.jolbox" % "bonecp" % "0.8.0.RELEASE"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.22` to `2.1.2`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.2) - [Version Diff](https://github.com/zio/zio/compare/v2.0.22...v2.1.2)