### PR TITLE
zio: 2.1.4 -> 2.1.5

### DIFF
--- a/examples/zio/build.sbt
+++ b/examples/zio/build.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "dev.zio" %% "zio" % "2.1.4"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.5"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
 libraryDependencies += "com.h2database" % "h2" % "2.2.224"
 libraryDependencies += "com.jolbox" % "bonecp" % "0.8.0.RELEASE"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.4` to `2.1.5`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.5) - [Version Diff](https://github.com/zio/zio/compare/v2.1.4...v2.1.5)