### PR TITLE
jetty-runner: 9.4.49.v20220914 -> 9.4.54.v20240208

### DIFF
--- a/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
+++ b/src/main/scala/com/earldouglas/xwp/JettyPlugin.scala
@@ -18,7 +18,7 @@ object JettyPlugin extends AutoPlugin {
   override val projectConfigurations = Seq(Jetty)
 
   val jettyRunner =
-    "org.eclipse.jetty" % "jetty-runner" % "9.4.49.v20220914"
+    "org.eclipse.jetty" % "jetty-runner" % "9.4.54.v20240208"
 
   override lazy val projectSettings =
     ContainerPlugin.containerSettings(Jetty) ++


### PR DESCRIPTION
📦 Updates org.eclipse.jetty:jetty-runner from `9.4.49.v20220914` to `9.4.54.v20240208`