### PR TITLE
zio: 2.1.7 -> 2.1.8

### DIFF
--- a/examples/zio/build.sbt
+++ b/examples/zio/build.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "dev.zio" %% "zio" % "2.1.7"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.8"
 libraryDependencies += "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided"
 libraryDependencies += "com.h2database" % "h2" % "2.3.230"
 libraryDependencies += "com.jolbox" % "bonecp" % "0.8.0.RELEASE"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.7` to `2.1.8`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.8) - [Version Diff](https://github.com/zio/zio/compare/v2.1.7...v2.1.8)